### PR TITLE
feat(paynow): add PayNow QR code generation for bill splitting

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
+    "qrcode": "^1.5.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "tailwind-merge": "^3.5.0",
@@ -33,6 +34,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^24.12.0",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
-      react-router:
-        specifier: ^7.14.0
-        version: 7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -955,10 +952,6 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1525,16 +1518,6 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react-router@7.14.0:
-    resolution: {integrity: sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -1581,9 +1564,6 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2651,8 +2631,6 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie@1.1.1: {}
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -3183,14 +3161,6 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
-    dependencies:
-      cookie: 1.1.1
-      react: 19.2.4
-      set-cookie-parser: 2.7.2
-    optionalDependencies:
-      react-dom: 19.2.4(react@19.2.4)
-
   react@19.2.4: {}
 
   redent@3.0.0:
@@ -3238,8 +3208,6 @@ snapshots:
   semver@7.7.4: {}
 
   set-blocking@2.0.0: {}
-
-  set-cookie-parser@2.7.2: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,18 @@ importers:
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.4)
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       react:
         specifier: ^19.2.4
         version: 19.2.4
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      react-router:
+        specifier: ^7.14.0
+        version: 7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -45,6 +51,9 @@ importers:
       '@types/node':
         specifier: ^24.12.0
         version: 24.12.0
+      '@types/qrcode':
+        specifier: ^1.5.6
+        version: 1.5.6
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -717,6 +726,9 @@ packages:
   '@types/node@24.12.0':
     resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
 
+  '@types/qrcode@1.5.6':
+    resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -908,6 +920,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
   caniuse-lite@1.0.30001780:
     resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
 
@@ -918,6 +934,9 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -935,6 +954,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -963,6 +986,10 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
@@ -976,6 +1003,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -998,6 +1028,9 @@ packages:
 
   embla-carousel@8.6.0:
     resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
@@ -1109,6 +1142,10 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -1128,6 +1165,10 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -1184,6 +1225,10 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -1330,6 +1375,10 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -1393,13 +1442,25 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -1426,6 +1487,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
+
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1447,6 +1512,11 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
@@ -1454,6 +1524,16 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-router@7.14.0:
+    resolution: {integrity: sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -1463,9 +1543,16 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1492,6 +1579,12 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1512,6 +1605,14 @@ packages:
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -1709,6 +1810,9 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1723,6 +1827,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -1730,8 +1838,19 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -2274,6 +2393,10 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/qrcode@1.5.6':
+    dependencies:
+      '@types/node': 24.12.0
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -2499,6 +2622,8 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase@5.3.1: {}
+
   caniuse-lite@1.0.30001780: {}
 
   chai@6.2.2: {}
@@ -2507,6 +2632,12 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
 
   clsx@2.1.1: {}
 
@@ -2519,6 +2650,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2546,6 +2679,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@1.2.0: {}
+
   decimal.js@10.6.0: {}
 
   deep-is@0.1.4: {}
@@ -2553,6 +2688,8 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
+
+  dijkstrajs@1.0.3: {}
 
   dom-accessibility-api@0.5.16: {}
 
@@ -2571,6 +2708,8 @@ snapshots:
       embla-carousel: 8.6.0
 
   embla-carousel@8.6.0: {}
+
+  emoji-regex@8.0.0: {}
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -2720,6 +2859,11 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -2736,6 +2880,8 @@ snapshots:
     optional: true
 
   gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
 
   glob-parent@6.0.2:
     dependencies:
@@ -2777,6 +2923,8 @@ snapshots:
   indent-string@4.0.0: {}
 
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -2903,6 +3051,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -2962,13 +3114,23 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-try@2.2.0: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -2988,6 +3150,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pngjs@5.0.0: {}
+
   postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
@@ -3006,12 +3170,26 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
+
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
 
   react-is@17.0.2: {}
+
+  react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.4
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
 
   react@19.2.4: {}
 
@@ -3020,7 +3198,11 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
+
+  require-main-filename@2.0.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -3055,6 +3237,10 @@ snapshots:
 
   semver@7.7.4: {}
 
+  set-blocking@2.0.0: {}
+
+  set-cookie-parser@2.7.2: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -3068,6 +3254,16 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@4.0.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-indent@3.0.0:
     dependencies:
@@ -3208,6 +3404,8 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  which-module@2.0.1: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -3219,11 +3417,38 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
 
+  y18n@4.0.3: {}
+
   yallist@3.1.1: {}
+
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   yocto-queue@0.1.0: {}
 

--- a/src/features/split-results/logic/receiptSplitImageLight.ts
+++ b/src/features/split-results/logic/receiptSplitImageLight.ts
@@ -1,3 +1,4 @@
+import QRCode from 'qrcode';
 import type { ChargeState, Person, Receipt, SplitResult } from '@shared/types';
 import { formatCurrencyFromCents, parseNumber } from '@shared/logic/core/money';
 import {
@@ -12,6 +13,7 @@ import {
   drawRoundedRect,
   drawLightTwoColumnRow,
 } from '@features/split-results/logic/receiptSplitImageLightHelpers';
+import { buildPaynowString } from '@shared/logic/core/paynow';
 
 type GenerateReceiptSplitImageLightOptions = {
   people: Person[];
@@ -25,10 +27,15 @@ type GenerateReceiptSplitImageLightOptions = {
   includeItemDetails: boolean;
   receiptName?: string;
   currency?: string;
+  /** Normalised payer PayNow mobile (+65XXXXXXXX). When set, a QR code is embedded in each person card. */
+  payerMobile?: string;
 };
 
 // Layout constants
 const CANVAS_PADDING = 56; // horizontal/vertical page margin
+const QR_SIZE = 160; // QR code dimensions (square)
+const QR_GAP = 20; // vertical gap between nested card and QR block
+const QR_LABEL_H = 28; // height reserved for the "Scan to pay" label
 const CARD_PAD = 32;
 const AVATAR_RADIUS = 22;
 const AVATAR_GAP = 16; // gap between avatar and name
@@ -73,6 +80,46 @@ function computeRequiredHeight(options: GenerateReceiptSplitImageLightOptions): 
   return Math.max(240, Math.ceil(y + CANVAS_PADDING));
 }
 
+// ─── QR helpers ───────────────────────────────────────────────────────────────
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.src = src;
+  });
+}
+
+/**
+ * Pre-generate one QR HTMLImageElement per person.
+ * Returns an empty map if payerMobile is falsy or QR generation fails.
+ */
+async function preloadQrImages(
+  people: Person[],
+  split: SplitResult,
+  payerMobile: string | undefined,
+): Promise<Map<string, HTMLImageElement>> {
+  if (!payerMobile) return new Map();
+  const entries = await Promise.all(
+    people.map(async (person) => {
+      const amountCents = split.totalByPersonCents[person.id] ?? 0;
+      if (amountCents <= 0) return null;
+      try {
+        const paynowStr = buildPaynowString(payerMobile, amountCents);
+        const dataUrl = await QRCode.toDataURL(paynowStr, { width: QR_SIZE, margin: 1 });
+        const img = await loadImage(dataUrl);
+        return [person.id, img] as const;
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return new Map(entries.filter((e): e is [string, HTMLImageElement] => e !== null));
+}
+
+// ─── Main export ───────────────────────────────────────────────────────────────
+
 export async function generateReceiptSplitImageLight(
   options: GenerateReceiptSplitImageLightOptions,
 ): Promise<Blob> {
@@ -86,6 +133,9 @@ export async function generateReceiptSplitImageLight(
 
   const ctx = scratch.getContext('2d');
   if (!ctx) throw new Error('Unable to initialize canvas renderer.');
+
+  // Pre-generate QR images (async, before any drawing)
+  const qrImages = await preloadQrImages(options.people, options.split, options.payerMobile);
 
   // Light background
   ctx.fillStyle = '#f5f5f5';
@@ -144,6 +194,7 @@ export async function generateReceiptSplitImageLight(
             options.receipts,
             options.splitByReceipt,
             options.includeItemDetails,
+            qrImages.has(person.id),
           ),
         );
       }
@@ -165,6 +216,7 @@ export async function generateReceiptSplitImageLight(
           serviceCharge: options.serviceCharge,
           gst: options.gst,
           currency: options.currency,
+          qrImage: qrImages.get(person.id),
         });
       }
 
@@ -260,6 +312,7 @@ function measurePersonCardHeight(
   receipts: Receipt[] | undefined,
   splitByReceipt: SplitResult[] | undefined,
   includeLineItems: boolean,
+  hasQr: boolean = false,
 ): number {
   let nestedBodyH: number;
 
@@ -281,7 +334,8 @@ function measurePersonCardHeight(
   }
 
   const nestedH = NESTED_PAD + nestedBodyH + NESTED_BOTTOM_PAD;
-  return CARD_PAD + HEADER_H + BODY_TOP_PAD + nestedH + CARD_PAD;
+  const qrBlockH = hasQr ? QR_GAP + QR_SIZE + QR_LABEL_H : 0;
+  return CARD_PAD + HEADER_H + BODY_TOP_PAD + nestedH + qrBlockH + CARD_PAD;
 }
 
 // ─── Person card drawing ──────────────────────────────────────────────────────
@@ -301,6 +355,7 @@ type PersonCardArgs = {
   serviceCharge: ChargeState;
   gst: ChargeState;
   currency?: string;
+  qrImage?: HTMLImageElement;
 };
 
 function drawPersonCard(ctx: CanvasRenderingContext2D, args: PersonCardArgs): void {
@@ -338,7 +393,8 @@ function drawPersonCard(ctx: CanvasRenderingContext2D, args: PersonCardArgs): vo
   const nestedX = innerX;
   const nestedY = args.y + CARD_PAD + HEADER_H + BODY_TOP_PAD;
   const nestedW = innerWidth;
-  const nestedH = args.height - (CARD_PAD + HEADER_H + BODY_TOP_PAD + CARD_PAD);
+  const qrBlockH = args.qrImage ? QR_GAP + QR_SIZE + QR_LABEL_H : 0;
+  const nestedH = args.height - (CARD_PAD + HEADER_H + BODY_TOP_PAD + qrBlockH + CARD_PAD);
   drawNestedCard(ctx, nestedX, nestedY, nestedW, nestedH);
 
   const niX = nestedX + NESTED_PAD;
@@ -507,6 +563,20 @@ function drawPersonCard(ctx: CanvasRenderingContext2D, args: PersonCardArgs): vo
         size: 20,
       });
     }
+  }
+
+  // ── QR code block ────────────────────────────────────────────────────────────
+  if (args.qrImage) {
+    const qrY = args.y + args.height - CARD_PAD - QR_LABEL_H - QR_SIZE;
+    // Centre the QR horizontally within the card
+    const qrX = args.x + (args.width - QR_SIZE) / 2;
+    ctx.drawImage(args.qrImage, qrX, qrY, QR_SIZE, QR_SIZE);
+    // Label below QR
+    ctx.fillStyle = '#49454f';
+    ctx.font = '500 18px system-ui, -apple-system, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText('Scan to pay', args.x + args.width / 2, qrY + QR_SIZE + 20);
+    ctx.textAlign = 'left';
   }
 }
 

--- a/src/features/split-results/logic/receiptSplitImageLight.ts
+++ b/src/features/split-results/logic/receiptSplitImageLight.ts
@@ -12,6 +12,7 @@ import {
   drawRoundedRect,
   drawLightTwoColumnRow,
 } from '@features/split-results/logic/receiptSplitImageLightHelpers';
+import { normalizeMobile } from '@shared/logic/core/paynow';
 import { generatePaynowQrDataUrls } from '@shared/logic/core/paynowQr';
 
 type GenerateReceiptSplitImageLightOptions = {
@@ -54,6 +55,8 @@ const GRAND_TOTAL_AFTER_GAP = 32; // gap below grand total card
 
 function computeRequiredHeight(options: GenerateReceiptSplitImageLightOptions): number {
   const COLS = 2;
+  const hasValidMobile = !!options.payerMobile && !!normalizeMobile(options.payerMobile);
+  const sgdSplit = options.sgdSplit ?? options.split;
 
   let y = CANVAS_PADDING + 36 + 40; // start + title + subtitle
   y += GRAND_TOTAL_CARD_H + GRAND_TOTAL_AFTER_GAP;
@@ -65,9 +68,11 @@ function computeRequiredHeight(options: GenerateReceiptSplitImageLightOptions): 
       const rowPeople = options.people.slice(rowStart, Math.min(rowStart + COLS, options.people.length));
       let rowHeight = 0;
       for (const person of rowPeople) {
+        const amountCents = sgdSplit.totalByPersonCents[person.id] ?? 0;
+        const hasQr = hasValidMobile && amountCents > 0;
         rowHeight = Math.max(
           rowHeight,
-          measurePersonCardHeight(person.id, options.split, options.receipts, options.splitByReceipt, options.includeItemDetails),
+          measurePersonCardHeight(person.id, options.split, options.receipts, options.splitByReceipt, options.includeItemDetails, hasQr),
         );
       }
       y += rowHeight + BETWEEN_CARD_GAP;

--- a/src/features/split-results/logic/receiptSplitImageLight.ts
+++ b/src/features/split-results/logic/receiptSplitImageLight.ts
@@ -1,4 +1,3 @@
-import QRCode from 'qrcode';
 import type { ChargeState, Person, Receipt, SplitResult } from '@shared/types';
 import { formatCurrencyFromCents, parseNumber } from '@shared/logic/core/money';
 import {
@@ -13,7 +12,7 @@ import {
   drawRoundedRect,
   drawLightTwoColumnRow,
 } from '@features/split-results/logic/receiptSplitImageLightHelpers';
-import { buildPaynowString } from '@shared/logic/core/paynow';
+import { generatePaynowQrDataUrls } from '@shared/logic/core/paynowQr';
 
 type GenerateReceiptSplitImageLightOptions = {
   people: Person[];
@@ -29,6 +28,8 @@ type GenerateReceiptSplitImageLightOptions = {
   currency?: string;
   /** Normalised payer PayNow mobile (+65XXXXXXXX). When set, a QR code is embedded in each person card. */
   payerMobile?: string;
+  /** SGD-denominated split used for QR amounts. Falls back to `split` when omitted. */
+  sgdSplit?: SplitResult;
 };
 
 // Layout constants
@@ -91,31 +92,19 @@ function loadImage(src: string): Promise<HTMLImageElement> {
   });
 }
 
-/**
- * Pre-generate one QR HTMLImageElement per person.
- * Returns an empty map if payerMobile is falsy or QR generation fails.
- */
 async function preloadQrImages(
   people: Person[],
   split: SplitResult,
   payerMobile: string | undefined,
 ): Promise<Map<string, HTMLImageElement>> {
   if (!payerMobile) return new Map();
+  const dataUrls = await generatePaynowQrDataUrls(people, split, payerMobile, QR_SIZE);
   const entries = await Promise.all(
-    people.map(async (person) => {
-      const amountCents = split.totalByPersonCents[person.id] ?? 0;
-      if (amountCents <= 0) return null;
-      try {
-        const paynowStr = buildPaynowString(payerMobile, amountCents);
-        const dataUrl = await QRCode.toDataURL(paynowStr, { width: QR_SIZE, margin: 1 });
-        const img = await loadImage(dataUrl);
-        return [person.id, img] as const;
-      } catch {
-        return null;
-      }
-    }),
+    Object.entries(dataUrls)
+      .filter(([, url]) => url)
+      .map(async ([id, url]) => [id, await loadImage(url)] as const),
   );
-  return new Map(entries.filter((e): e is [string, HTMLImageElement] => e !== null));
+  return new Map(entries);
 }
 
 // ─── Main export ───────────────────────────────────────────────────────────────
@@ -135,7 +124,7 @@ export async function generateReceiptSplitImageLight(
   if (!ctx) throw new Error('Unable to initialize canvas renderer.');
 
   // Pre-generate QR images (async, before any drawing)
-  const qrImages = await preloadQrImages(options.people, options.split, options.payerMobile);
+  const qrImages = await preloadQrImages(options.people, options.sgdSplit ?? options.split, options.payerMobile);
 
   // Light background
   ctx.fillStyle = '#f5f5f5';

--- a/src/pages/components/workspace/shared/PersonCard.tsx
+++ b/src/pages/components/workspace/shared/PersonCard.tsx
@@ -18,6 +18,7 @@ interface Props {
   showDetails?: boolean;
   receiptBreakdown?: ReceiptBreakdownEntry[];
   currency?: string;
+  qrDataUrl?: string;
 }
 
 function buildChargeLabel(label: string, charge: ChargeState): string {
@@ -40,6 +41,7 @@ export function PersonCard({
   showDetails = false,
   receiptBreakdown,
   currency,
+  qrDataUrl,
 }: Props) {
   const lines = split.lineItemsByPerson[person.id] ?? [];
   const total = split.totalByPersonCents[person.id] ?? 0;
@@ -55,13 +57,22 @@ export function PersonCard({
           <PersonAvatar name={person.name} colorIndex={colorIndex} />
           <h3 className="text-2xl font-bold text-primary">{person.name}</h3>
         </div>
-        <div className="text-right">
-          <span className="text-[10px] uppercase font-semibold tracking-widest text-on-surface-variant block leading-none mb-1">
-            {receiptBreakdown ? 'Total Consolidated' : 'Total Due'}
-          </span>
-          <p className="text-3xl font-semibold text-on-surface leading-none font-headline">
-            {formatCurrencyFromCents(total, currency)}
-          </p>
+        <div className="flex items-start gap-3">
+          {qrDataUrl && (
+            <img
+              src={qrDataUrl}
+              alt={`PayNow QR for ${person.name}`}
+              className="w-20 h-20 rounded-lg border border-outline-variant/20"
+            />
+          )}
+          <div className="text-right">
+            <span className="text-[10px] uppercase font-semibold tracking-widest text-on-surface-variant block leading-none mb-1">
+              {receiptBreakdown ? 'Total Consolidated' : 'Total Due'}
+            </span>
+            <p className="text-3xl font-semibold text-on-surface leading-none font-headline">
+              {formatCurrencyFromCents(total, currency)}
+            </p>
+          </div>
         </div>
       </div>
 

--- a/src/pages/components/workspace/steps/SummaryStep.tsx
+++ b/src/pages/components/workspace/steps/SummaryStep.tsx
@@ -1,4 +1,5 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import QRCode from 'qrcode';
 import type { ChargeState, Person, Receipt, SplitResult } from '@shared/types';
 import { formatCurrencyFromCents, getCurrencySymbol } from '@shared/logic/core/money';
 import { generateReceiptSplitImageLight } from '@features/split-results/logic/receiptSplitImageLight';
@@ -15,6 +16,7 @@ import { BASE_CURRENCY } from '@shared/constants';
 import { cn } from '@shared/utils/cn';
 import { convertSplitResult } from '@shared/logic/core/exchangeRates';
 import { useReceiptStore } from '@shared/stores/receiptStore';
+import { normalizeMobile, buildPaynowString } from '@shared/logic/core/paynow';
 
 type Props = {
   people: Person[];
@@ -59,8 +61,13 @@ export function SummaryStep({
   const [exportError, setExportError] = useState<string | null>(null);
   const [editingTabId, setEditingTabId] = useState<string | null>(null);
   const [editingTabName, setEditingTabName] = useState('');
+  const [mobileError, setMobileError] = useState<string | null>(null);
+  const [qrDataUrls, setQrDataUrls] = useState<Record<string, string>>({});
   const tabInputRef = useRef<HTMLInputElement>(null);
   const copyTimeoutRef = useRef<number | null>(null);
+
+  const payerMobile = useReceiptStore((s) => s.payerMobile);
+  const setPayerMobile = useReceiptStore((s) => s.setPayerMobile);
 
   const startEditingTab = (id: string, name: string) => {
     setEditingTabId(id);
@@ -118,13 +125,60 @@ export function SummaryStep({
 
   const nativeShareSupported = getShareSupport() === 'native';
 
+  // The split used for QR amounts is always in SGD regardless of display currency.
+  const sgdSplitForQr = isForeignCurrency ? (convertedSplit ?? currentSplit) : currentSplit;
+
+  // Stable key that changes whenever the per-person SGD amounts change (e.g. on tab switch).
+  const qrAmountsKey = people
+    .map((p) => `${p.id}:${sgdSplitForQr.totalByPersonCents[p.id] ?? 0}`)
+    .join(',');
+
+  useEffect(() => {
+    const normalised = normalizeMobile(payerMobile);
+    if (!normalised) {
+      setQrDataUrls({});
+      return;
+    }
+    let cancelled = false;
+    Promise.all(
+      people.map(async (person) => {
+        const amountCents = sgdSplitForQr.totalByPersonCents[person.id] ?? 0;
+        if (amountCents <= 0) return [person.id, ''] as const;
+        try {
+          const paynowStr = buildPaynowString(normalised, amountCents);
+          const dataUrl = await QRCode.toDataURL(paynowStr, { width: 160, margin: 1 });
+          return [person.id, dataUrl] as const;
+        } catch {
+          return [person.id, ''] as const;
+        }
+      }),
+    ).then((entries) => {
+      if (!cancelled) setQrDataUrls(Object.fromEntries(entries));
+    });
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [payerMobile, qrAmountsKey]);
+
+  const handlePayerMobileChange = (value: string) => {
+    setPayerMobile(value);
+    setMobileError(null);
+  };
+
+  const handlePayerMobileBlur = () => {
+    if (payerMobile.trim() && !normalizeMobile(payerMobile)) {
+      setMobileError('Enter a valid SG mobile number, e.g. +65 9123 4567');
+    }
+  };
+
   const handleDownload = async () => {
     setBusy('downloading');
     setExportError(null);
     try {
       const blob = await generateReceiptSplitImageLight({
         people,
-        split: displaySplit,
+        split: sgdSplitForQr,
         receipts,
         splitByReceipt,
         discount: currentDiscount,
@@ -134,6 +188,7 @@ export function SummaryStep({
         reconciliationCents,
         includeItemDetails: showDetails,
         currency: displayCurrency,
+        payerMobile: normalizeMobile(payerMobile) ?? undefined,
       });
       if (nativeShareSupported) {
         const result = await shareFinalSplit({ image: blob, fileName: 'split-result.png' });
@@ -355,6 +410,7 @@ export function SummaryStep({
                 gst={currentGst}
                 showDetails={showDetails}
                 currency={displayCurrency}
+                qrDataUrl={qrDataUrls[person.id]}
                 receiptBreakdown={
                   activeTab === 'total' && isMultiReceipt
                     ? receipts.map((r, i) => {
@@ -416,6 +472,25 @@ export function SummaryStep({
                 {(grandTotal / 100).toFixed(2)}
               </span>
             </div>
+
+            {/* PayNow input */}
+            <div className="mb-4">
+              <label className="block text-xs font-semibold text-white/60 uppercase tracking-widest mb-1.5">
+                Your PayNow Number
+              </label>
+              <input
+                type="tel"
+                value={payerMobile}
+                onChange={(e) => handlePayerMobileChange(e.target.value)}
+                onBlur={handlePayerMobileBlur}
+                placeholder="+65 9123 4567"
+                className="w-full bg-white/10 text-white placeholder:text-white/30 rounded-xl px-3 py-2 text-sm font-medium outline-none focus:ring-2 focus:ring-white/30"
+              />
+              {mobileError && (
+                <p className="text-xs text-red-300 mt-1">{mobileError}</p>
+              )}
+            </div>
+
             <div className="border-t border-white/10 pt-4 flex items-center gap-2.5">
               <span
                 className="material-symbols-outlined !text-sm text-cyan-300"

--- a/src/pages/components/workspace/steps/SummaryStep.tsx
+++ b/src/pages/components/workspace/steps/SummaryStep.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from 'react';
-import QRCode from 'qrcode';
 import type { ChargeState, Person, Receipt, SplitResult } from '@shared/types';
 import { formatCurrencyFromCents, getCurrencySymbol } from '@shared/logic/core/money';
 import { generateReceiptSplitImageLight } from '@features/split-results/logic/receiptSplitImageLight';
@@ -16,7 +15,8 @@ import { BASE_CURRENCY } from '@shared/constants';
 import { cn } from '@shared/utils/cn';
 import { convertSplitResult } from '@shared/logic/core/exchangeRates';
 import { useReceiptStore } from '@shared/stores/receiptStore';
-import { normalizeMobile, buildPaynowString } from '@shared/logic/core/paynow';
+import { normalizeMobile } from '@shared/logic/core/paynow';
+import { generatePaynowQrDataUrls } from '@shared/logic/core/paynowQr';
 
 type Props = {
   people: Person[];
@@ -134,30 +134,15 @@ export function SummaryStep({
     .join(',');
 
   useEffect(() => {
-    const normalised = normalizeMobile(payerMobile);
-    if (!normalised) {
-      setQrDataUrls({});
-      return;
-    }
     let cancelled = false;
-    Promise.all(
-      people.map(async (person) => {
-        const amountCents = sgdSplitForQr.totalByPersonCents[person.id] ?? 0;
-        if (amountCents <= 0) return [person.id, ''] as const;
-        try {
-          const paynowStr = buildPaynowString(normalised, amountCents);
-          const dataUrl = await QRCode.toDataURL(paynowStr, { width: 160, margin: 1 });
-          return [person.id, dataUrl] as const;
-        } catch {
-          return [person.id, ''] as const;
-        }
-      }),
-    ).then((entries) => {
-      if (!cancelled) setQrDataUrls(Object.fromEntries(entries));
+    generatePaynowQrDataUrls(people, sgdSplitForQr, payerMobile).then((urls) => {
+      if (!cancelled) setQrDataUrls(urls);
     });
     return () => {
       cancelled = true;
     };
+    // qrAmountsKey encodes every person's SGD amount, so it covers `people` and
+    // `sgdSplitForQr` transitively — no need to list them directly.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [payerMobile, qrAmountsKey]);
 
@@ -178,7 +163,8 @@ export function SummaryStep({
     try {
       const blob = await generateReceiptSplitImageLight({
         people,
-        split: sgdSplitForQr,
+        split: displaySplit,
+        sgdSplit: sgdSplitForQr,
         receipts,
         splitByReceipt,
         discount: currentDiscount,
@@ -475,10 +461,11 @@ export function SummaryStep({
 
             {/* PayNow input */}
             <div className="mb-4">
-              <label className="block text-xs font-semibold text-white/60 uppercase tracking-widest mb-1.5">
+              <label htmlFor="payer-mobile" className="block text-xs font-semibold text-white/60 uppercase tracking-widest mb-1.5">
                 Your PayNow Number
               </label>
               <input
+                id="payer-mobile"
                 type="tel"
                 value={payerMobile}
                 onChange={(e) => handlePayerMobileChange(e.target.value)}

--- a/src/pages/hooks/useReceiptSplitterController.ts
+++ b/src/pages/hooks/useReceiptSplitterController.ts
@@ -15,6 +15,7 @@ export function useReceiptSplitterController() {
     initialize,
     reset,
     fetchAndSetExchangeRates,
+    payerMobile,
   } = useReceiptStore(
     useShallow((state) => ({
       isScanning: Object.values(state.scanStateByReceipt).some((s) => s.isScanning),
@@ -26,6 +27,7 @@ export function useReceiptSplitterController() {
       initialize: state.initialize,
       reset: state.reset,
       fetchAndSetExchangeRates: state.fetchAndSetExchangeRates,
+      payerMobile: state.payerMobile,
     })),
   );
 
@@ -45,6 +47,6 @@ export function useReceiptSplitterController() {
     };
   }, [reset]);
 
-  useDraftPersistence({ initialized, people, receipts, activeReceiptId });
+  useDraftPersistence({ initialized, people, receipts, activeReceiptId, payerMobile });
   useLoadingTicker({ isActive: isScanning, onTick: advanceLoadingMessage });
 }

--- a/src/shared/api/storage.test.ts
+++ b/src/shared/api/storage.test.ts
@@ -301,6 +301,7 @@ const minimalDraftState = {
   people: [{ id: 'p1', name: 'Alice' }],
   receipts: [receipt1],
   activeReceiptId: 'r1',
+  payerMobile: '',
 };
 
 describe('exportDraftToJson', () => {
@@ -483,6 +484,7 @@ describe('storage availability failures', () => {
         people: [],
         receipts: [],
         activeReceiptId: '',
+        payerMobile: '',
         savedAt: '',
       }),
     ).not.toThrow();

--- a/src/shared/api/storage.ts
+++ b/src/shared/api/storage.ts
@@ -28,12 +28,14 @@ export function exportDraftToJson(state: {
   people: Person[];
   receipts: Receipt[];
   activeReceiptId: string;
+  payerMobile: string;
 }): string {
   const draft: SessionDraft = {
     version: 2,
     people: state.people,
     receipts: state.receipts,
     activeReceiptId: state.activeReceiptId,
+    payerMobile: state.payerMobile,
     savedAt: new Date().toISOString(),
   };
   return JSON.stringify(draft, null, 2);
@@ -218,6 +220,7 @@ function migrateV1ToSessionDraft(parsed: Record<string, unknown>): SessionDraft 
     people,
     receipts: [receipt],
     activeReceiptId: receiptId,
+    payerMobile: '',
     savedAt: typeof parsed.savedAt === 'string' ? parsed.savedAt : new Date().toISOString(),
   };
 }
@@ -242,6 +245,7 @@ function normalizeSessionDraft(parsed: Record<string, unknown>): SessionDraft | 
     people,
     receipts,
     activeReceiptId,
+    payerMobile: typeof parsed.payerMobile === 'string' ? parsed.payerMobile : '',
     savedAt: typeof parsed.savedAt === 'string' ? parsed.savedAt : new Date().toISOString(),
   };
 }

--- a/src/shared/hooks/useDraftPersistence.ts
+++ b/src/shared/hooks/useDraftPersistence.ts
@@ -7,6 +7,7 @@ type UseDraftPersistenceArgs = {
   people: Person[];
   receipts: Receipt[];
   activeReceiptId: string;
+  payerMobile: string;
 };
 
 export function useDraftPersistence({
@@ -14,6 +15,7 @@ export function useDraftPersistence({
   people,
   receipts,
   activeReceiptId,
+  payerMobile,
 }: UseDraftPersistenceArgs): void {
   useEffect(() => {
     if (!initialized) return;
@@ -22,7 +24,8 @@ export function useDraftPersistence({
       people,
       receipts,
       activeReceiptId,
+      payerMobile,
       savedAt: new Date().toISOString(),
     });
-  }, [initialized, people, receipts, activeReceiptId]);
+  }, [initialized, people, receipts, activeReceiptId, payerMobile]);
 }

--- a/src/shared/logic/core/paynow.test.ts
+++ b/src/shared/logic/core/paynow.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { crc16, normalizeMobile, buildPaynowString } from './paynow';
+
+// ─── crc16 ───────────────────────────────────────────────────────────────────
+
+describe('crc16', () => {
+  it('returns 0xFFFF for empty string (init value, no bytes processed)', () => {
+    expect(crc16('')).toBe(0xffff);
+  });
+
+  it('returns 0x29B1 for "123456789" (CRC16-CCITT standard test vector)', () => {
+    expect(crc16('123456789')).toBe(0x29b1);
+  });
+
+  it('returns a 16-bit value', () => {
+    expect(crc16('hello')).toBeGreaterThanOrEqual(0);
+    expect(crc16('hello')).toBeLessThanOrEqual(0xffff);
+  });
+
+  it('is deterministic', () => {
+    const input = '000201010212';
+    expect(crc16(input)).toBe(crc16(input));
+  });
+
+  it('differs for different inputs', () => {
+    expect(crc16('abc')).not.toBe(crc16('def'));
+  });
+});
+
+// ─── normalizeMobile ─────────────────────────────────────────────────────────
+
+describe('normalizeMobile', () => {
+  it('accepts canonical +65 format', () => {
+    expect(normalizeMobile('+6591234567')).toBe('+6591234567');
+  });
+
+  it('accepts 65-prefixed without +', () => {
+    expect(normalizeMobile('6591234567')).toBe('+6591234567');
+  });
+
+  it('accepts bare 8-digit number starting with 9', () => {
+    expect(normalizeMobile('91234567')).toBe('+6591234567');
+  });
+
+  it('accepts bare 8-digit number starting with 8', () => {
+    expect(normalizeMobile('81234567')).toBe('+6581234567');
+  });
+
+  it('strips spaces', () => {
+    expect(normalizeMobile('+65 9123 4567')).toBe('+6591234567');
+  });
+
+  it('strips dashes', () => {
+    expect(normalizeMobile('+65-9123-4567')).toBe('+6591234567');
+  });
+
+  it('returns null for empty string', () => {
+    expect(normalizeMobile('')).toBeNull();
+  });
+
+  it('returns null for number starting with wrong digit (7)', () => {
+    expect(normalizeMobile('71234567')).toBeNull();
+  });
+
+  it('returns null for 7-digit number', () => {
+    expect(normalizeMobile('9123456')).toBeNull();
+  });
+
+  it('returns null for 9-digit number', () => {
+    expect(normalizeMobile('912345678')).toBeNull();
+  });
+
+  it('returns null for letters', () => {
+    expect(normalizeMobile('hello')).toBeNull();
+  });
+
+  it('returns null for wrong country code length', () => {
+    // 11 digits total but not matching 65+8
+    expect(normalizeMobile('12345678901')).toBeNull();
+  });
+});
+
+// ─── buildPaynowString ────────────────────────────────────────────────────────
+
+describe('buildPaynowString', () => {
+  const mobile = '+6591234567';
+  const amountCents = 1250; // $12.50
+
+  it('starts with payload format indicator 000201', () => {
+    const str = buildPaynowString(mobile, amountCents);
+    expect(str.startsWith('000201')).toBe(true);
+  });
+
+  it('contains SG.PAYNOW GUID', () => {
+    const str = buildPaynowString(mobile, amountCents);
+    expect(str).toContain('SG.PAYNOW');
+  });
+
+  it('contains the normalised mobile number', () => {
+    const str = buildPaynowString(mobile, amountCents);
+    expect(str).toContain('+6591234567');
+  });
+
+  it('contains the correct amount formatted as decimal', () => {
+    const str = buildPaynowString(mobile, amountCents);
+    expect(str).toContain('12.50');
+  });
+
+  it('contains SGD currency code 702', () => {
+    const str = buildPaynowString(mobile, amountCents);
+    expect(str).toContain('5303702');
+  });
+
+  it('contains Singapore city', () => {
+    const str = buildPaynowString(mobile, amountCents);
+    expect(str).toContain('Singapore');
+  });
+
+  it('ends with a 4-char hex CRC after "6304"', () => {
+    const str = buildPaynowString(mobile, amountCents);
+    const crcIdx = str.lastIndexOf('6304');
+    expect(crcIdx).toBeGreaterThan(-1);
+    const crcPart = str.slice(crcIdx + 4);
+    expect(crcPart).toHaveLength(4);
+    expect(/^[0-9A-F]{4}$/.test(crcPart)).toBe(true);
+  });
+
+  it('the CRC is correct (verify by recomputing)', () => {
+    const str = buildPaynowString(mobile, amountCents);
+    // The CRC covers everything up to and including the "6304" tag+length
+    const payloadForCrc = str.slice(0, str.lastIndexOf('6304') + 4);
+    const expectedCrc = crc16(payloadForCrc).toString(16).toUpperCase().padStart(4, '0');
+    const actualCrc = str.slice(-4);
+    expect(actualCrc).toBe(expectedCrc);
+  });
+
+  it('accepts bare 8-digit number (normalises internally)', () => {
+    expect(() => buildPaynowString('91234567', amountCents)).not.toThrow();
+    const str = buildPaynowString('91234567', amountCents);
+    expect(str).toContain('+6591234567');
+  });
+
+  it('throws for invalid mobile', () => {
+    expect(() => buildPaynowString('invalid', amountCents)).toThrow();
+  });
+
+  it('formats whole dollar amounts correctly', () => {
+    const str = buildPaynowString(mobile, 500); // $5.00
+    expect(str).toContain('5.00');
+  });
+
+  it('formats sub-dollar amounts correctly', () => {
+    const str = buildPaynowString(mobile, 50); // $0.50
+    expect(str).toContain('0.50');
+  });
+
+  it('produces different strings for different amounts', () => {
+    const a = buildPaynowString(mobile, 100);
+    const b = buildPaynowString(mobile, 200);
+    expect(a).not.toBe(b);
+  });
+
+  it('produces different strings for different mobile numbers', () => {
+    const a = buildPaynowString('+6591234567', 1000);
+    const b = buildPaynowString('+6598765432', 1000);
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/shared/logic/core/paynow.ts
+++ b/src/shared/logic/core/paynow.ts
@@ -1,0 +1,108 @@
+/**
+ * PayNow QR code string builder (EMVCo / SGQR format).
+ *
+ * Generates the TLV payload string that can be rendered into a QR code by
+ * any standard QR library (e.g. the `qrcode` npm package).  When scanned by
+ * a Singapore banking app the app pre-fills the recipient and amount.
+ *
+ * Reference: MAS SGQR specification (based on EMVCo Merchant-Presented QR).
+ */
+
+// ─── CRC16-CCITT ─────────────────────────────────────────────────────────────
+
+/** CRC16-CCITT (poly 0x1021, init 0xFFFF) — required by the SGQR spec. */
+export function crc16(str: string): number {
+  let crc = 0xffff;
+  for (let i = 0; i < str.length; i++) {
+    crc ^= str.charCodeAt(i) << 8;
+    for (let j = 0; j < 8; j++) {
+      crc = crc & 0x8000 ? ((crc << 1) ^ 0x1021) & 0xffff : (crc << 1) & 0xffff;
+    }
+  }
+  return crc;
+}
+
+// ─── TLV helpers ─────────────────────────────────────────────────────────────
+
+/** Encode a single EMVCo TLV field: ID (2 chars) + length (2 chars, zero-padded) + value. */
+function tlv(id: string, value: string): string {
+  const len = value.length.toString().padStart(2, '0');
+  return id + len + value;
+}
+
+// ─── Mobile normalisation ─────────────────────────────────────────────────────
+
+/**
+ * Normalise a raw PayNow mobile number input to the canonical `+65XXXXXXXX` form.
+ *
+ * Accepts:
+ *   - `+6591234567`  (already canonical)
+ *   - `6591234567`   (country code without +)
+ *   - `91234567`     (bare 8-digit SG number)
+ *
+ * Returns `null` if the input cannot be normalised to a valid SG mobile number.
+ */
+export function normalizeMobile(raw: string): string | null {
+  // Strip all spaces, dashes, and parentheses.
+  const stripped = raw.replace(/[\s\-()]/g, '');
+
+  let digits: string;
+
+  if (stripped.startsWith('+65')) {
+    digits = stripped.slice(3);
+  } else if (stripped.startsWith('65') && stripped.length === 10) {
+    digits = stripped.slice(2);
+  } else {
+    digits = stripped;
+  }
+
+  // SG mobile numbers are exactly 8 digits and start with 8 or 9.
+  if (!/^[89]\d{7}$/.test(digits)) {
+    return null;
+  }
+
+  return `+65${digits}`;
+}
+
+// ─── PayNow string builder ───────────────────────────────────────────────────
+
+/**
+ * Build the PayNow QR payload string for a peer-to-peer transfer.
+ *
+ * @param mobile      Recipient's Singapore mobile number (any accepted format —
+ *                    will be normalised internally).
+ * @param amountCents Amount owed in SGD cents (integer).  Must be ≥ 1.
+ * @returns           The full SGQR/EMVCo TLV string, including CRC checksum.
+ *                    Pass this directly to `QRCode.toDataURL(string)`.
+ * @throws            If `mobile` is not a valid SG mobile number.
+ */
+export function buildPaynowString(mobile: string, amountCents: number): string {
+  const normalised = normalizeMobile(mobile);
+  if (!normalised) {
+    throw new Error(`Invalid PayNow mobile number: "${mobile}"`);
+  }
+
+  const amount = (amountCents / 100).toFixed(2);
+
+  // ID 26 — Merchant Account Information (PayNow-specific sub-TLVs)
+  const merchantAccountInfo = tlv(
+    '26',
+    tlv('00', 'SG.PAYNOW') + // GUID
+      tlv('01', '0') + // Proxy type: 0 = mobile
+      tlv('02', normalised) + // Proxy value
+      tlv('03', '0'), // Amount editable: 0 = fixed
+  );
+
+  // Build the payload up to (but not including) the CRC value itself.
+  const payloadWithoutCrc =
+    tlv('00', '01') + // Payload Format Indicator
+    tlv('01', '12') + // Point of Initiation: 12 = dynamic
+    merchantAccountInfo +
+    tlv('53', '702') + // Transaction Currency: 702 = SGD
+    tlv('54', amount) + // Transaction Amount
+    tlv('60', 'Singapore') + // Merchant City
+    '6304'; // CRC field ID + length (value appended below)
+
+  const checksum = crc16(payloadWithoutCrc).toString(16).toUpperCase().padStart(4, '0');
+  return payloadWithoutCrc + checksum;
+}

--- a/src/shared/logic/core/paynowQr.ts
+++ b/src/shared/logic/core/paynowQr.ts
@@ -1,0 +1,32 @@
+import QRCode from 'qrcode';
+import type { Person, SplitResult } from '@shared/types';
+import { buildPaynowString, normalizeMobile } from './paynow';
+
+/**
+ * Generate PayNow QR data URLs for each person.
+ * Returns an empty object if `payerMobile` is invalid or empty.
+ * Persons with zero or negative amounts get an empty string value.
+ */
+export async function generatePaynowQrDataUrls(
+  people: Person[],
+  split: SplitResult,
+  payerMobile: string,
+  qrSize = 160,
+): Promise<Record<string, string>> {
+  const normalised = normalizeMobile(payerMobile);
+  if (!normalised) return {};
+  const entries = await Promise.all(
+    people.map(async (person) => {
+      const amountCents = split.totalByPersonCents[person.id] ?? 0;
+      if (amountCents <= 0) return [person.id, ''] as const;
+      try {
+        const paynowStr = buildPaynowString(normalised, amountCents);
+        const dataUrl = await QRCode.toDataURL(paynowStr, { width: qrSize, margin: 1 });
+        return [person.id, dataUrl] as const;
+      } catch {
+        return [person.id, ''] as const;
+      }
+    }),
+  );
+  return Object.fromEntries(entries);
+}

--- a/src/shared/stores/receiptStore.ts
+++ b/src/shared/stores/receiptStore.ts
@@ -129,6 +129,7 @@ type ReceiptStoreState = {
   people: Person[];
   receipts: Receipt[];
   activeReceiptId: string;
+  payerMobile: string;
 
   // Exchange rates
   exchangeRates: Record<string, number>;
@@ -170,6 +171,9 @@ type ReceiptStoreActions = {
   getExportJson: () => string;
   importFromJson: (raw: string) => void;
 
+  // Payer actions
+  setPayerMobile: (mobile: string) => void;
+
   // Receipt management actions
   addReceipt: () => void;
   removeReceipt: (receiptId: string) => void;
@@ -204,6 +208,7 @@ const initialState: ReceiptStoreState = {
   people: [],
   receipts: [],
   activeReceiptId: '',
+  payerMobile: '',
 
   // Exchange rates (loaded from localStorage or fallback)
   exchangeRates: loadExchangeRates() ?? FALLBACK_RATES_TO_SGD,
@@ -389,6 +394,7 @@ export const useReceiptStore = create<ReceiptStore>((set, get) => {
           people: draft.people,
           receipts,
           activeReceiptId: draft.activeReceiptId,
+          payerMobile: draft.payerMobile,
         });
       } else {
         const blankReceipt = createBlankReceipt([], 'Receipt 1');
@@ -406,6 +412,7 @@ export const useReceiptStore = create<ReceiptStore>((set, get) => {
         people: [],
         receipts: [],
         activeReceiptId: '',
+        payerMobile: '',
       });
     },
     addPeopleFromInput: (rawInput) => {
@@ -645,8 +652,8 @@ export const useReceiptStore = create<ReceiptStore>((set, get) => {
       applyPayloadToReceipt(fixture.buildResponse(), activeReceiptId, people);
     },
     getExportJson: () => {
-      const { people, receipts, activeReceiptId } = get();
-      return exportDraftToJson({ people, receipts, activeReceiptId });
+      const { people, receipts, activeReceiptId, payerMobile } = get();
+      return exportDraftToJson({ people, receipts, activeReceiptId, payerMobile });
     },
     importFromJson: (raw) => {
       const draft = importDraftFromJson(raw);
@@ -660,8 +667,13 @@ export const useReceiptStore = create<ReceiptStore>((set, get) => {
           items: buildInitialItems(r.items, draft.people),
         })),
         activeReceiptId: draft.activeReceiptId,
+        payerMobile: draft.payerMobile,
       });
     },
+
+    // --- Payer actions ---
+
+    setPayerMobile: (mobile) => set({ payerMobile: mobile }),
 
     // --- Receipt management actions ---
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -125,6 +125,7 @@ export type SessionDraft = {
   people: Person[];
   receipts: Receipt[];
   activeReceiptId: string;
+  payerMobile: string;
   savedAt: string;
 };
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -29,6 +29,9 @@ Object.defineProperty(window, 'matchMedia', {
   }),
 });
 
+// jsdom doesn't implement scrollTo
+window.scrollTo = () => {};
+
 afterEach(() => {
   cleanup();
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
+    exclude: ['**/node_modules/**', '.claude/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],


### PR DESCRIPTION
## Summary

- Adds PayNow QR code generation so each person can scan-to-pay their share directly from the summary screen
- Implements SGQR/EMVCo TLV string builder (`paynow.ts`) with CRC16-CCITT checksum and Singapore mobile number normalisation
- Extracts shared `generatePaynowQrDataUrls` helper (`paynowQr.ts`) used by both the summary UI and the PNG export canvas
- Persists the payer's PayNow mobile number in localStorage so it survives page refreshes

## What changed

**New files**
- `src/shared/logic/core/paynow.ts` — pure SGQR payload builder (`buildPaynowString`, `normalizeMobile`, `crc16`)
- `src/shared/logic/core/paynow.test.ts` — 168-line unit test suite covering CRC, mobile normalisation, and full payload round-trips
- `src/shared/logic/core/paynowQr.ts` — async helper that converts per-person SGD amounts + payer mobile into a `Record<personId, dataUrl>` map

**Updated files**
- `SummaryStep.tsx` — adds a PayNow mobile input in the grand-total card; generates QR data URLs and passes them down to `PersonCard`
- `PersonCard.tsx` — renders a QR code image when `qrDataUrl` is provided
- `receiptSplitImageLight.ts` — draws PayNow QR codes onto the exported PNG canvas for each person
- `receiptStore.ts` / `storage.ts` / `useDraftPersistence.ts` — store and persist `payerMobile`
- `package.json` / `pnpm-lock.yaml` — adds `qrcode` + `@types/qrcode`; removes unused `react-router`

## Test plan

- [ ] Enter a valid SG mobile number (e.g. `91234567` or `+65 9123 4567`) — QR codes appear on each person card
- [ ] Enter an invalid number — inline error shown, no QR codes rendered
- [ ] Leave mobile blank — no QR codes, no error
- [ ] Export PNG — QR codes appear beside each person's amount on the image
- [ ] Refresh the page — mobile number is restored from localStorage
- [ ] Run `pnpm test` — all `paynow.test.ts` cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)