### PR TITLE
feat: PDF uploads, native share, dynamic export canvas, currency symbol fix

### DIFF
--- a/src/features/split-results/logic/receiptSplitImageLight.ts
+++ b/src/features/split-results/logic/receiptSplitImageLight.ts
@@ -2,7 +2,6 @@ import type { ChargeState, Person, Receipt, SplitResult } from '@shared/types';
 import { formatCurrencyFromCents, parseNumber } from '@shared/logic/core/money';
 import {
   CANVAS_WIDTH,
-  SCRATCH_HEIGHT,
   canvasToBlob,
   formatGeneratedAt,
   formatPercent,
@@ -42,6 +41,40 @@ const BODY_TOP_PAD = 24; // gap between header and nested card
 const NESTED_BOTTOM_PAD = 24; // padding below last charge row inside nested card
 const BETWEEN_CARD_GAP = 20; // vertical gap between person cards
 
+function computeRequiredHeight(options: GenerateReceiptSplitImageLightOptions): number {
+  const COLS = 2;
+  const COL_GAP = 24;
+  const cardWidth = CANVAS_WIDTH - 56 * 2;
+  const colWidth = Math.floor((cardWidth - COL_GAP * (COLS - 1)) / COLS);
+  // suppress unused var — colWidth drives height indirectly via measurePersonCardHeight
+  void colWidth;
+
+  let y = 56 + 36 + 40; // start + title + subtitle
+  y += 116 + 32; // grand total card height + gap
+
+  if (options.people.length === 0) {
+    y += 72 + BETWEEN_CARD_GAP;
+  } else {
+    for (let rowStart = 0; rowStart < options.people.length; rowStart += COLS) {
+      const rowPeople = options.people.slice(rowStart, Math.min(rowStart + COLS, options.people.length));
+      let rowHeight = 0;
+      for (const person of rowPeople) {
+        rowHeight = Math.max(
+          rowHeight,
+          measurePersonCardHeight(person.id, options.split, options.receipts, options.splitByReceipt, options.includeItemDetails),
+        );
+      }
+      y += rowHeight + BETWEEN_CARD_GAP;
+    }
+  }
+
+  if (options.split.unassignedItemCount > 0) {
+    y += 72 + BETWEEN_CARD_GAP;
+  }
+
+  return Math.max(240, Math.ceil(y + 56));
+}
+
 export async function generateReceiptSplitImageLight(
   options: GenerateReceiptSplitImageLightOptions,
 ): Promise<Blob> {
@@ -51,7 +84,7 @@ export async function generateReceiptSplitImageLight(
 
   const scratch = document.createElement('canvas');
   scratch.width = CANVAS_WIDTH;
-  scratch.height = SCRATCH_HEIGHT;
+  scratch.height = computeRequiredHeight(options);
 
   const ctx = scratch.getContext('2d');
   if (!ctx) throw new Error('Unable to initialize canvas renderer.');
@@ -160,9 +193,6 @@ export async function generateReceiptSplitImageLight(
   }
 
   const requiredHeight = Math.max(240, Math.ceil(y + 56));
-  if (requiredHeight > scratch.height) {
-    throw new Error('Export is too large. Try with fewer items.');
-  }
 
   const output = document.createElement('canvas');
   output.width = CANVAS_WIDTH;

--- a/src/features/split-results/logic/receiptSplitImageLight.ts
+++ b/src/features/split-results/logic/receiptSplitImageLight.ts
@@ -28,6 +28,7 @@ type GenerateReceiptSplitImageLightOptions = {
 };
 
 // Layout constants
+const CANVAS_PADDING = 56; // horizontal/vertical page margin
 const CARD_PAD = 32;
 const AVATAR_RADIUS = 22;
 const AVATAR_GAP = 16; // gap between avatar and name
@@ -40,13 +41,14 @@ const DIVIDER_H = 22; // space around divider line
 const BODY_TOP_PAD = 24; // gap between header and nested card
 const NESTED_BOTTOM_PAD = 24; // padding below last charge row inside nested card
 const BETWEEN_CARD_GAP = 20; // vertical gap between person cards
+const GRAND_TOTAL_CARD_H = 116; // fixed height of the grand total card
+const GRAND_TOTAL_AFTER_GAP = 32; // gap below grand total card
 
 function computeRequiredHeight(options: GenerateReceiptSplitImageLightOptions): number {
   const COLS = 2;
-  const cardWidth = CANVAS_WIDTH - 56 * 2;
 
-  let y = 56 + 36 + 40; // start + title + subtitle
-  y += 116 + 32; // grand total card height + gap
+  let y = CANVAS_PADDING + 36 + 40; // start + title + subtitle
+  y += GRAND_TOTAL_CARD_H + GRAND_TOTAL_AFTER_GAP;
 
   if (options.people.length === 0) {
     y += 72 + BETWEEN_CARD_GAP;
@@ -68,7 +70,7 @@ function computeRequiredHeight(options: GenerateReceiptSplitImageLightOptions): 
     y += 72 + BETWEEN_CARD_GAP;
   }
 
-  return Math.max(240, Math.ceil(y + 56));
+  return Math.max(240, Math.ceil(y + CANVAS_PADDING));
 }
 
 export async function generateReceiptSplitImageLight(
@@ -89,8 +91,8 @@ export async function generateReceiptSplitImageLight(
   ctx.fillStyle = '#f5f5f5';
   ctx.fillRect(0, 0, scratch.width, scratch.height);
 
-  let y = 56;
-  const x = 56;
+  let y = CANVAS_PADDING;
+  const x = CANVAS_PADDING;
   const cardWidth = CANVAS_WIDTH - x * 2;
 
   // Title
@@ -112,7 +114,7 @@ export async function generateReceiptSplitImageLight(
     split: options.split,
     currency: options.currency,
   });
-  y += 32;
+  y += GRAND_TOTAL_AFTER_GAP;
 
   // Person cards — 2-column grid
   if (options.people.length === 0) {
@@ -188,7 +190,7 @@ export async function generateReceiptSplitImageLight(
     y += warnH + BETWEEN_CARD_GAP;
   }
 
-  const requiredHeight = Math.max(240, Math.ceil(y + 56));
+  const requiredHeight = Math.max(240, Math.ceil(y + CANVAS_PADDING));
 
   const output = document.createElement('canvas');
   output.width = CANVAS_WIDTH;
@@ -210,7 +212,7 @@ type GrandTotalCardArgs = {
 };
 
 function drawGrandTotalCard(ctx: CanvasRenderingContext2D, args: GrandTotalCardArgs): number {
-  const h = 116;
+  const h = GRAND_TOTAL_CARD_H;
 
   ctx.save();
   const grad = ctx.createLinearGradient(args.x, args.y, args.x + args.width, args.y);

--- a/src/features/split-results/logic/receiptSplitImageLight.ts
+++ b/src/features/split-results/logic/receiptSplitImageLight.ts
@@ -43,11 +43,7 @@ const BETWEEN_CARD_GAP = 20; // vertical gap between person cards
 
 function computeRequiredHeight(options: GenerateReceiptSplitImageLightOptions): number {
   const COLS = 2;
-  const COL_GAP = 24;
   const cardWidth = CANVAS_WIDTH - 56 * 2;
-  const colWidth = Math.floor((cardWidth - COL_GAP * (COLS - 1)) / COLS);
-  // suppress unused var — colWidth drives height indirectly via measurePersonCardHeight
-  void colWidth;
 
   let y = 56 + 36 + 40; // start + title + subtitle
   y += 116 + 32; // grand total card height + gap

--- a/src/pages/components/workspace/shared/GlobalChargesPanel.tsx
+++ b/src/pages/components/workspace/shared/GlobalChargesPanel.tsx
@@ -2,6 +2,8 @@ import type { ChargeState, SplitResult } from '@shared/types';
 import { ChargeToggle } from '@pages/components/workspace/shared/ChargeToggle';
 import { SummaryTotals } from '@pages/components/workspace/shared/SummaryTotals';
 import { ReconciliationNotice } from '@pages/components/workspace/shared/ReconciliationNotice';
+import { getCurrencySymbol } from '@shared/logic/core/money';
+import { BASE_CURRENCY } from '@shared/constants';
 
 interface Props {
   split: SplitResult;
@@ -67,7 +69,7 @@ export function GlobalChargesPanel({
           </label>
           <div className="relative">
             <span className="absolute left-4 top-1/2 -translate-y-1/2 text-on-surface-variant font-bold">
-              $
+              {getCurrencySymbol(currency ?? BASE_CURRENCY)}
             </span>
             <input
               id="receipt-total-new"

--- a/src/pages/components/workspace/shared/ReceiptImportActions.tsx
+++ b/src/pages/components/workspace/shared/ReceiptImportActions.tsx
@@ -52,7 +52,7 @@ export function ReceiptImportActions({
           <input
             ref={fileInputRef}
             type="file"
-            accept="image/*"
+            accept="image/*,application/pdf"
             data-testid="receipt-file-input"
             className="sr-only"
             onChange={handleFileChange}

--- a/src/pages/components/workspace/steps/SummaryStep.tsx
+++ b/src/pages/components/workspace/steps/SummaryStep.tsx
@@ -6,6 +6,8 @@ import {
   buildSplitShareText,
   copyShareText,
   downloadImage,
+  getShareSupport,
+  shareFinalSplit,
 } from '@features/split-results/logic/shareSplit';
 import { PersonCard } from '@pages/components/workspace/shared/PersonCard';
 import { ReceiptNameField } from '@pages/components/workspace/shared/ReceiptNameField';
@@ -114,6 +116,8 @@ export function SummaryStep({
 
   const grandTotal = Object.values(displaySplit.totalByPersonCents).reduce((s, v) => s + v, 0);
 
+  const nativeShareSupported = getShareSupport() === 'native';
+
   const handleDownload = async () => {
     setBusy('downloading');
     setExportError(null);
@@ -131,7 +135,14 @@ export function SummaryStep({
         includeItemDetails: showDetails,
         currency: displayCurrency,
       });
-      await downloadImage(blob, 'split-result.png');
+      if (nativeShareSupported) {
+        const result = await shareFinalSplit({ image: blob, fileName: 'split-result.png' });
+        if (result === 'fallback') {
+          await downloadImage(blob, 'split-result.png');
+        }
+      } else {
+        await downloadImage(blob, 'split-result.png');
+      }
     } catch {
       setExportError('Failed to generate image.');
     } finally {
@@ -426,8 +437,10 @@ export function SummaryStep({
               disabled={busy !== null}
               className="flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-surface-container-highest text-primary font-bold text-sm hover:bg-primary hover:text-on-primary transition-all disabled:opacity-60"
             >
-              <span className="material-symbols-outlined text-base">image</span>
-              {busy === 'downloading' ? 'Generating…' : 'Save Image'}
+              <span className="material-symbols-outlined text-base">
+                {nativeShareSupported ? 'share' : 'image'}
+              </span>
+              {busy === 'downloading' ? 'Generating…' : nativeShareSupported ? 'Share' : 'Save Image'}
             </button>
             <button
               type="button"

--- a/src/pages/components/workspace/steps/SummaryStep.tsx
+++ b/src/pages/components/workspace/steps/SummaryStep.tsx
@@ -143,7 +143,8 @@ export function SummaryStep({
       } else {
         await downloadImage(blob, 'split-result.png');
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') return;
       setExportError('Failed to generate image.');
     } finally {
       setBusy(null);


### PR DESCRIPTION
## Summary

- **PDF receipts**: The upload file picker now accepts `image/*,application/pdf` so users can upload PDF receipts directly. Camera capture stays image-only. The MIME type already flows through to the Gemini API correctly.
- **Native share**: On mobile devices that support the Web Share API with file sharing (iOS Safari, Android Chrome), the "Save Image" button becomes "Share" and opens the native share sheet. Falls back silently to download if the sheet is dismissed or unavailable.
- **Currency symbol fix**: The receipt total override input in `GlobalChargesPanel` was hardcoded to `$`. It now uses `getCurrencySymbol(currency ?? BASE_CURRENCY)` so JPY receipts show `¥`, EUR shows `€`, etc.
- **Dynamic export canvas**: `receiptSplitImageLight.ts` previously pre-allocated a fixed 24,000px scratch canvas and threw `'Export is too large'` for big receipts. A `computeRequiredHeight()` helper now mirrors the layout math ahead of drawing so the canvas is allocated at exactly the needed size.

## Test plan

- [ ] Upload a PDF receipt — file picker should accept it and Gemini scan should work
- [ ] On an iOS/Android device, go to Summary step → "Share" button appears and opens the native share sheet
- [ ] On desktop, Summary step still shows "Save Image" and downloads a PNG
- [ ] Switch a receipt to a non-SGD currency (e.g. JPY) — receipt total input prefix should update to `¥`
- [ ] Export a receipt with many items — should generate without throwing an error
- [ ] All 170 existing tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)