### PR TITLE
refactor: remove legacy simple/advanced mode naming

### DIFF
--- a/src/features/receipt-scanner/index.ts
+++ b/src/features/receipt-scanner/index.ts
@@ -3,5 +3,5 @@ export {
   analyzeReceiptWithGemini,
   applyOcrPayload,
   buildLocalMockOcrResponse,
-  buildSimpleModeMockOcrResponse,
+  buildMockOcrResponse,
 } from '@features/receipt-scanner/logic/ocr';

--- a/src/features/receipt-scanner/logic/ocr.ts
+++ b/src/features/receipt-scanner/logic/ocr.ts
@@ -11,7 +11,7 @@ import { createItemFromOcr } from '@features/receipt-scanner/logic/itemMapper';
 import { toNullableNumber, roundMoney } from '@shared/logic/core/money';
 export {
   buildLocalMockOcrResponse,
-  buildSimpleModeMockOcrResponse,
+  buildMockOcrResponse,
 } from '@features/receipt-scanner/logic/ocrFixtures';
 import {
   geminiReceiptSchema,

--- a/src/features/receipt-scanner/logic/ocrFixtures.ts
+++ b/src/features/receipt-scanner/logic/ocrFixtures.ts
@@ -82,6 +82,6 @@ export function buildLocalMockOcrResponse(): OcrResponse {
   return MOCK_RECEIPT_FIXTURES[0].buildResponse();
 }
 
-export function buildSimpleModeMockOcrResponse(): OcrResponse {
+export function buildMockOcrResponse(): OcrResponse {
   return MOCK_RECEIPT_FIXTURES[1].buildResponse();
 }

--- a/src/pages/ReceiptSplitterPage.test.tsx
+++ b/src/pages/ReceiptSplitterPage.test.tsx
@@ -135,7 +135,7 @@ describe('ReceiptSplitterPage integration', () => {
   describe('People step', () => {
     it('renders the people step as the initial step with continue disabled', () => {
       render(<ReceiptSplitterPage />);
-      expect(screen.getByTestId('simple-wizard')).toBeInTheDocument();
+      expect(screen.getByTestId('workspace')).toBeInTheDocument();
       expect(screen.getByTestId('people-empty-state')).toBeInTheDocument();
       expect(screen.getByTestId('wizard-continue-btn')).toBeDisabled();
     });

--- a/src/pages/components/workspace/BottomNav.tsx
+++ b/src/pages/components/workspace/BottomNav.tsx
@@ -1,9 +1,9 @@
 import { cn } from '@shared/utils/cn';
 import { getContinueLabel } from '@pages/logic/wizardSteps';
-import type { ItemsSubPhase, SimpleWizardStep } from '@pages/types';
+import type { ItemsSubPhase, WizardStep } from '@pages/types';
 
 interface Props {
-  activeStep: SimpleWizardStep;
+  activeStep: WizardStep;
   itemsSubPhase: ItemsSubPhase;
   isLastAssignableItem: boolean;
   canContinue: boolean;

--- a/src/pages/components/workspace/ProgressIndicator.tsx
+++ b/src/pages/components/workspace/ProgressIndicator.tsx
@@ -1,9 +1,9 @@
 import { cn } from '@shared/utils/cn';
 import { getStepNumber, isStepCompleted, STEP_LABELS, STEP_ORDER } from '@pages/logic/wizardSteps';
-import type { ItemsSubPhase, SimpleWizardStep } from '@pages/types';
+import type { ItemsSubPhase, WizardStep } from '@pages/types';
 
 interface Props {
-  activeStep: SimpleWizardStep;
+  activeStep: WizardStep;
   itemsSubPhase: ItemsSubPhase;
   assignedItemCount: number;
   detectedItemsCount: number;

--- a/src/pages/components/workspace/TopAppBar.tsx
+++ b/src/pages/components/workspace/TopAppBar.tsx
@@ -1,8 +1,8 @@
 import { cn } from '@shared/utils/cn';
-import type { ItemsSubPhase, SimpleWizardStep } from '@pages/types';
+import type { ItemsSubPhase, WizardStep } from '@pages/types';
 
-const STEP_ORDER: SimpleWizardStep[] = ['people', 'receipt', 'items', 'final'];
-const STEP_LABELS: Record<SimpleWizardStep, string> = {
+const STEP_ORDER: WizardStep[] = ['people', 'receipt', 'items', 'final'];
+const STEP_LABELS: Record<WizardStep, string> = {
   people: 'People',
   receipt: 'Receipt',
   items: 'Assign',
@@ -10,7 +10,7 @@ const STEP_LABELS: Record<SimpleWizardStep, string> = {
 };
 
 interface Props {
-  activeStep: SimpleWizardStep;
+  activeStep: WizardStep;
   itemsSubPhase: ItemsSubPhase;
   assignedItemCount: number;
   detectedItemsCount: number;

--- a/src/pages/components/workspace/Workspace.tsx
+++ b/src/pages/components/workspace/Workspace.tsx
@@ -4,7 +4,7 @@ import { MOCK_RECEIPT_FIXTURES } from '@features/receipt-scanner/logic/ocrFixtur
 import { useReceiptStore } from '@shared/stores/receiptStore';
 import { useReceiptSplit } from '@shared/hooks/useReceiptSplit';
 import { getAssignedItemsCount, getDetectedItemsCount } from '@pages/logic/wizardValidation';
-import { useSimpleWizard } from '@pages/hooks/useSimpleWizard';
+import { useWizard } from '@pages/hooks/useWizard';
 import { useReceiptSplitterController } from '@pages/hooks/useReceiptSplitterController';
 import { TopAppBar } from '@pages/components/workspace/TopAppBar';
 import { BottomNav } from '@pages/components/workspace/BottomNav';
@@ -93,7 +93,7 @@ export function Workspace() {
     handleNext,
     handleBack,
     handleAddReceipt,
-  } = useSimpleWizard(items, people, normalizeItems, receipts, activeReceiptId, setActiveReceiptId);
+  } = useWizard(items, people, normalizeItems, receipts, activeReceiptId, setActiveReceiptId);
 
   const detectedItemsCount = useMemo(() => getDetectedItemsCount(items), [items]);
   const assignedItemCount = useMemo(() => getAssignedItemsCount(items, people), [items, people]);
@@ -129,7 +129,7 @@ export function Workspace() {
   return (
     <div
       className="bg-surface text-on-surface font-body min-h-screen flex flex-col"
-      data-testid="simple-wizard"
+      data-testid="workspace"
     >
       <TopAppBar
         activeStep={activeStep}

--- a/src/pages/components/workspace/steps/AssignStep.tsx
+++ b/src/pages/components/workspace/steps/AssignStep.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { formatCurrencyFromCents, parseCurrencyToCents } from '@shared/logic/core/money';
-import { isSimpleItemAssigned } from '@pages/logic/wizardValidation';
+import { isItemAssigned } from '@pages/logic/wizardValidation';
 import {
   togglePersonInAssignment,
   selectAllPeople,
@@ -140,7 +140,7 @@ function AssignPhase({
   currency,
 }: AssignPhaseProps) {
   const activeItem = items[activeItemIndex] ?? null;
-  const isAssigned = activeItem ? isSimpleItemAssigned(activeItem, validPeopleSet) : false;
+  const isAssigned = activeItem ? isItemAssigned(activeItem, validPeopleSet) : false;
 
   const handleTogglePerson = (personId: string, checked: boolean) => {
     if (!activeItem) return;

--- a/src/pages/hooks/useWizard.ts
+++ b/src/pages/hooks/useWizard.ts
@@ -2,12 +2,12 @@ import { useEffect, useState } from 'react';
 import { useReceiptStore } from '@shared/stores/receiptStore';
 import { useGeminiStore } from '@shared/stores/geminiStore';
 import type { EditableItem, Person, Receipt } from '@shared/types';
-import type { ItemsSubPhase, SimpleWizardStep } from '@pages/types';
-import { loadSimpleWizardState, saveSimpleWizardState } from '@pages/logic/persistence';
+import type { ItemsSubPhase, WizardStep } from '@pages/types';
+import { loadWizardState, saveWizardState } from '@pages/logic/persistence';
 import { clampActiveItemIndex, resolveWizardState } from '@pages/logic/wizardState';
 import { isStepValid } from '@pages/logic/wizardValidation';
 
-export function useSimpleWizard(
+export function useWizard(
   items: EditableItem[],
   people: Person[],
   normalizeItems: () => void,
@@ -19,8 +19,8 @@ export function useSimpleWizard(
   const setShowApiKeyModal = useGeminiStore((state) => state.setShowApiKeyModal);
   const addReceipt = useReceiptStore((state) => state.addReceipt);
 
-  const [initialWizardState] = useState(() => loadSimpleWizardState());
-  const [activeStepState, setActiveStep] = useState<SimpleWizardStep>(
+  const [initialWizardState] = useState(() => loadWizardState());
+  const [activeStepState, setActiveStep] = useState<WizardStep>(
     initialWizardState?.step ?? 'people',
   );
   const [itemsSubPhaseState, setItemsSubPhase] = useState<ItemsSubPhase>(
@@ -37,7 +37,7 @@ export function useSimpleWizard(
   const safeActiveItemIndex = clampActiveItemIndex(activeItemIndex, items.length);
 
   useEffect(() => {
-    saveSimpleWizardState({
+    saveWizardState({
       step: activeStep,
       itemsSubPhase,
       activeItemIndex: safeActiveItemIndex,

--- a/src/pages/logic/persistence.test.ts
+++ b/src/pages/logic/persistence.test.ts
@@ -1,28 +1,28 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { LOCAL_STORAGE_SIMPLE_WIZARD_STATE_KEY } from '@shared/constants';
-import { loadSimpleWizardState, saveSimpleWizardState } from '@pages/logic/persistence';
+import { LOCAL_STORAGE_WIZARD_STATE_KEY } from '@shared/constants';
+import { loadWizardState, saveWizardState } from '@pages/logic/persistence';
 
-describe('loadSimpleWizardState', () => {
+describe('loadWizardState', () => {
   beforeEach(() => {
     window.localStorage.clear();
   });
 
   it('returns null for malformed JSON', () => {
-    window.localStorage.setItem(LOCAL_STORAGE_SIMPLE_WIZARD_STATE_KEY, '{broken');
-    expect(loadSimpleWizardState()).toBeNull();
+    window.localStorage.setItem(LOCAL_STORAGE_WIZARD_STATE_KEY, '{broken');
+    expect(loadWizardState()).toBeNull();
   });
 
   it('returns null for non-v1 version', () => {
     window.localStorage.setItem(
-      LOCAL_STORAGE_SIMPLE_WIZARD_STATE_KEY,
+      LOCAL_STORAGE_WIZARD_STATE_KEY,
       JSON.stringify({ version: 2, step: 'people', itemsSubPhase: 'assign', activeItemIndex: 0 }),
     );
-    expect(loadSimpleWizardState()).toBeNull();
+    expect(loadWizardState()).toBeNull();
   });
 
   it('loads a valid v1 state', () => {
-    saveSimpleWizardState({ step: 'items', itemsSubPhase: 'review', activeItemIndex: 2 });
-    const state = loadSimpleWizardState();
+    saveWizardState({ step: 'items', itemsSubPhase: 'review', activeItemIndex: 2 });
+    const state = loadWizardState();
     expect(state).toEqual({
       version: 1,
       step: 'items',
@@ -33,10 +33,10 @@ describe('loadSimpleWizardState', () => {
 
   it('defaults unknown step to "people"', () => {
     window.localStorage.setItem(
-      LOCAL_STORAGE_SIMPLE_WIZARD_STATE_KEY,
+      LOCAL_STORAGE_WIZARD_STATE_KEY,
       JSON.stringify({ version: 1, step: 'unknown', itemsSubPhase: 'assign', activeItemIndex: 0 }),
     );
-    const state = loadSimpleWizardState();
+    const state = loadWizardState();
     expect(state?.step).toBe('people');
   });
 });

--- a/src/pages/logic/persistence.ts
+++ b/src/pages/logic/persistence.ts
@@ -1,20 +1,20 @@
-import { LOCAL_STORAGE_SIMPLE_WIZARD_STATE_KEY } from '@shared/constants';
-import type { ItemsSubPhase, SimpleWizardStep } from '@pages/types';
+import { LOCAL_STORAGE_WIZARD_STATE_KEY } from '@shared/constants';
+import type { ItemsSubPhase, WizardStep } from '@pages/types';
 
-type PersistedSimpleWizardState = {
+type PersistedWizardState = {
   version: 1;
-  step: SimpleWizardStep;
+  step: WizardStep;
   itemsSubPhase: ItemsSubPhase;
   activeItemIndex: number;
 };
 
-export function loadSimpleWizardState(): PersistedSimpleWizardState | null {
+export function loadWizardState(): PersistedWizardState | null {
   if (typeof window === 'undefined') {
     return null;
   }
 
   try {
-    const raw = window.localStorage.getItem(LOCAL_STORAGE_SIMPLE_WIZARD_STATE_KEY);
+    const raw = window.localStorage.getItem(LOCAL_STORAGE_WIZARD_STATE_KEY);
     if (!raw) {
       return null;
     }
@@ -42,8 +42,8 @@ export function loadSimpleWizardState(): PersistedSimpleWizardState | null {
   }
 }
 
-export function saveSimpleWizardState(state: {
-  step: SimpleWizardStep;
+export function saveWizardState(state: {
+  step: WizardStep;
   itemsSubPhase: ItemsSubPhase;
   activeItemIndex: number;
 }): void {
@@ -51,7 +51,7 @@ export function saveSimpleWizardState(state: {
     return;
   }
 
-  const payload: PersistedSimpleWizardState = {
+  const payload: PersistedWizardState = {
     version: 1,
     step: state.step,
     itemsSubPhase: state.itemsSubPhase,
@@ -59,13 +59,13 @@ export function saveSimpleWizardState(state: {
   };
 
   try {
-    window.localStorage.setItem(LOCAL_STORAGE_SIMPLE_WIZARD_STATE_KEY, JSON.stringify(payload));
+    window.localStorage.setItem(LOCAL_STORAGE_WIZARD_STATE_KEY, JSON.stringify(payload));
   } catch {
     // Ignore storage write failures.
   }
 }
 
-function normalizeStep(value: unknown): SimpleWizardStep {
+function normalizeStep(value: unknown): WizardStep {
   return value === 'people' || value === 'receipt' || value === 'items' || value === 'final'
     ? value
     : 'people';

--- a/src/pages/logic/wizardState.ts
+++ b/src/pages/logic/wizardState.ts
@@ -1,5 +1,5 @@
 import type { EditableItem, Person } from '@shared/types';
-import type { ItemsSubPhase, SimpleWizardStep } from '@pages/types';
+import type { ItemsSubPhase, WizardStep } from '@pages/types';
 import { isStepValid } from '@pages/logic/wizardValidation';
 
 export function clampActiveItemIndex(index: number, itemCount: number): number {
@@ -8,11 +8,11 @@ export function clampActiveItemIndex(index: number, itemCount: number): number {
 }
 
 export function resolveWizardState(
-  activeStep: SimpleWizardStep,
+  activeStep: WizardStep,
   itemsSubPhase: ItemsSubPhase,
   items: EditableItem[],
   people: Person[],
-): { activeStep: SimpleWizardStep; itemsSubPhase: ItemsSubPhase } {
+): { activeStep: WizardStep; itemsSubPhase: ItemsSubPhase } {
   if (activeStep === 'final' && !isStepValid('items', { items, people })) {
     return { activeStep: 'items', itemsSubPhase: 'assign' };
   }

--- a/src/pages/logic/wizardSteps.ts
+++ b/src/pages/logic/wizardSteps.ts
@@ -1,17 +1,17 @@
-import type { ItemsSubPhase, SimpleWizardStep } from '@pages/types';
+import type { ItemsSubPhase, WizardStep } from '@pages/types';
 
-export const STEP_ORDER: SimpleWizardStep[] = ['people', 'receipt', 'items', 'final'];
+export const STEP_ORDER: WizardStep[] = ['people', 'receipt', 'items', 'final'];
 
-export function getStepNumber(step: SimpleWizardStep): number {
+export function getStepNumber(step: WizardStep): number {
   return STEP_ORDER.indexOf(step) + 1;
 }
 
-export function isStepCompleted(step: SimpleWizardStep, activeStep: SimpleWizardStep): boolean {
+export function isStepCompleted(step: WizardStep, activeStep: WizardStep): boolean {
   return STEP_ORDER.indexOf(step) < STEP_ORDER.indexOf(activeStep);
 }
 
 export function getContinueLabel(
-  activeStep: SimpleWizardStep,
+  activeStep: WizardStep,
   itemsSubPhase: ItemsSubPhase,
   isLastAssignableItem: boolean,
 ): string {
@@ -22,7 +22,7 @@ export function getContinueLabel(
   return 'Summary';
 }
 
-export const STEP_LABELS: Record<SimpleWizardStep, string> = {
+export const STEP_LABELS: Record<WizardStep, string> = {
   people: 'People',
   receipt: 'Receipt',
   items: 'Assign',

--- a/src/pages/logic/wizardValidation.ts
+++ b/src/pages/logic/wizardValidation.ts
@@ -1,6 +1,6 @@
 import type { EditableItem, Person } from '@shared/types';
 import { resolveDiscountedAmountCents } from '@shared/logic/computation/pricing';
-import type { SimpleWizardStep } from '@pages/types';
+import type { WizardStep } from '@pages/types';
 
 export function hasAnyValidReceiptItem(items: EditableItem[]): boolean {
   return items.some((item) => resolveDiscountedAmountCents(item) !== null);
@@ -13,10 +13,10 @@ export function getDetectedItemsCount(items: EditableItem[]): number {
 export function getAssignedItemsCount(items: EditableItem[], people: Person[]): number {
   const validPeople = new Set(people.map((person) => person.id));
 
-  return items.filter((item) => isSimpleItemAssigned(item, validPeople)).length;
+  return items.filter((item) => isItemAssigned(item, validPeople)).length;
 }
 
-export function isSimpleItemAssigned(item: EditableItem, validPeople: Set<string>): boolean {
+export function isItemAssigned(item: EditableItem, validPeople: Set<string>): boolean {
   if (item.assignment.mode !== 'equal') {
     return false;
   }
@@ -26,7 +26,7 @@ export function isSimpleItemAssigned(item: EditableItem, validPeople: Set<string
 }
 
 export function isStepValid(
-  step: SimpleWizardStep,
+  step: WizardStep,
   args: { items: EditableItem[]; people: Person[] },
 ): boolean {
   if (step === 'people') {

--- a/src/pages/types.ts
+++ b/src/pages/types.ts
@@ -1,6 +1,6 @@
-export const SIMPLE_WIZARD_STEPS = ['people', 'receipt', 'items', 'final'] as const;
+export const WIZARD_STEPS = ['people', 'receipt', 'items', 'final'] as const;
 
-export type SimpleWizardStep = (typeof SIMPLE_WIZARD_STEPS)[number];
+export type WizardStep = (typeof WIZARD_STEPS)[number];
 
 export type ItemsSubPhase = 'assign' | 'review';
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -37,7 +37,7 @@ export const GEMINI_MODELS = [
 export const DEFAULT_GEMINI_MODEL = GEMINI_MODELS[0];
 export const LOCAL_STORAGE_DRAFT_KEY = 'split:receipt-draft:v1';
 export const LOCAL_STORAGE_OCR_SETTINGS_KEY = 'split:ocr-settings:v1';
-export const LOCAL_STORAGE_SIMPLE_WIZARD_STATE_KEY = 'split:simple-wizard-state:v1';
+export const LOCAL_STORAGE_WIZARD_STATE_KEY = 'split:simple-wizard-state:v1';
 export const SESSION_STORAGE_GEMINI_API_KEY = 'split:gemini-api-key:session';
 export const LOCAL_STORAGE_EXCHANGE_RATES_KEY = 'split:exchange-rates:v1';
 

--- a/src/shared/logic/assignment/simpleAssignments.test.ts
+++ b/src/shared/logic/assignment/simpleAssignments.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Person } from '@shared/types';
-import { buildInitialItems, createSimpleEmptyItem } from './simpleAssignments';
+import { buildInitialItems, createDefaultItem } from './simpleAssignments';
 
 const people: Person[] = [
   { id: 'p1', name: 'Alice' },
@@ -42,9 +42,9 @@ describe('buildInitialItems', () => {
   });
 });
 
-describe('createSimpleEmptyItem', () => {
+describe('createDefaultItem', () => {
   it('creates an item assigned to all people in equal mode', () => {
-    const item = createSimpleEmptyItem(people);
+    const item = createDefaultItem(people);
     expect(item.assignment.mode).toBe('equal');
     expect(item.assignment.personIds).toEqual(['p1', 'p2']);
     expect(item.name).toBe('');
@@ -52,7 +52,7 @@ describe('createSimpleEmptyItem', () => {
   });
 
   it('creates an item with empty personIds when no people exist', () => {
-    const item = createSimpleEmptyItem([]);
+    const item = createDefaultItem([]);
     expect(item.assignment.personIds).toEqual([]);
   });
 });

--- a/src/shared/logic/assignment/simpleAssignments.ts
+++ b/src/shared/logic/assignment/simpleAssignments.ts
@@ -2,7 +2,7 @@ import type { EditableItem, Person } from '@shared/types';
 import { createId } from '@shared/logic/core/id';
 import { sanitizeItemAssignment } from '@shared/logic/assignment/items';
 
-export function createSimpleEmptyItem(people: Person[]): EditableItem {
+export function createDefaultItem(people: Person[]): EditableItem {
   const baseItem = {
     id: createId(),
     name: '',
@@ -52,7 +52,7 @@ export function syncItemsWithPeople(items: EditableItem[], people: Person[]): Ed
 
 export function buildInitialItems(items: EditableItem[], people: Person[]): EditableItem[] {
   if (items.length === 0) {
-    return [createSimpleEmptyItem(people)];
+    return [createDefaultItem(people)];
   }
 
   return syncItemsWithPeople(items, people);

--- a/src/shared/stores/receiptStore.ts
+++ b/src/shared/stores/receiptStore.ts
@@ -13,7 +13,7 @@ import { analyzeReceiptWithGemini, applyOcrPayload } from '@features/receipt-sca
 import { MOCK_RECEIPT_FIXTURES } from '@features/receipt-scanner/logic/ocrFixtures';
 import {
   buildInitialItems,
-  createSimpleEmptyItem,
+  createDefaultItem,
   convertItemsToSimpleEqualMode,
   syncItemsWithPeople,
 } from '@shared/logic/assignment/simpleAssignments';
@@ -28,7 +28,7 @@ function createBlankReceipt(people: Person[], name: string): Receipt {
   return {
     id: createId(),
     name,
-    items: [createSimpleEmptyItem(people)],
+    items: [createDefaultItem(people)],
     discount: { ...defaultDiscountState },
     serviceCharge: { ...defaultServiceChargeState },
     gst: { ...defaultGstState },
@@ -271,7 +271,7 @@ export const useReceiptStore = create<ReceiptStore>((set, get) => {
       set((state) => ({
         receipts: state.receipts.map((r) =>
           r.id === state.activeReceiptId
-            ? { ...r, items: [...r.items, createSimpleEmptyItem(state.people)] }
+            ? { ...r, items: [...r.items, createDefaultItem(state.people)] }
             : r,
         ),
       }));
@@ -342,7 +342,7 @@ export const useReceiptStore = create<ReceiptStore>((set, get) => {
                 receiptFile: file,
                 ...(file
                   ? {
-                      items: [createSimpleEmptyItem(state.people)],
+                      items: [createDefaultItem(state.people)],
                       discount: { ...defaultDiscountState },
                       serviceCharge: { ...defaultServiceChargeState },
                       gst: { ...defaultGstState },

--- a/src/tests/integration/persistence.test.ts
+++ b/src/tests/integration/persistence.test.ts
@@ -9,8 +9,8 @@ import {
   resetAllStores,
   seedStore,
 } from './testHelpers';
-import { loadSimpleWizardState, saveSimpleWizardState } from '@pages/logic/persistence';
-import type { ItemsSubPhase, SimpleWizardStep } from '@pages/types';
+import { loadWizardState, saveWizardState } from '@pages/logic/persistence';
+import type { ItemsSubPhase, WizardStep } from '@pages/types';
 
 beforeEach(() => {
   resetAllStores();
@@ -197,13 +197,13 @@ describe('Persistence integration', () => {
   it('wizard state persists and restores via localStorage', () => {
     const wizardState = {
       version: 1 as const,
-      step: 'items' as SimpleWizardStep,
+      step: 'items' as WizardStep,
       itemsSubPhase: 'review' as ItemsSubPhase,
       activeItemIndex: 2,
     };
 
-    saveSimpleWizardState(wizardState);
-    const loaded = loadSimpleWizardState();
+    saveWizardState(wizardState);
+    const loaded = loadWizardState();
 
     expect(loaded).not.toBeNull();
     expect(loaded!.step).toBe('items');
@@ -213,11 +213,11 @@ describe('Persistence integration', () => {
 
   it('wizard state handles invalid data gracefully', () => {
     window.localStorage.setItem('split:simple-wizard-state:v1', '{broken json');
-    const loaded = loadSimpleWizardState();
+    const loaded = loadWizardState();
     expect(loaded).toBeNull();
 
     window.localStorage.setItem('split:simple-wizard-state:v1', JSON.stringify({ version: 999 }));
-    const loaded2 = loadSimpleWizardState();
+    const loaded2 = loadWizardState();
     expect(loaded2).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Removes the `simple` prefix from all TypeScript identifiers that were named relative to the now-deleted "simple mode / advanced mode" distinction
- Pure rename — no logic or behaviour changes

## Renames

| Old | New |
|---|---|
| `SimpleWizardStep` | `WizardStep` |
| `SIMPLE_WIZARD_STEPS` | `WIZARD_STEPS` |
| `useSimpleWizard` + `useSimpleWizard.ts` | `useWizard` + `useWizard.ts` |
| `loadSimpleWizardState` / `saveSimpleWizardState` | `loadWizardState` / `saveWizardState` |
| `PersistedSimpleWizardState` | `PersistedWizardState` |
| `LOCAL_STORAGE_SIMPLE_WIZARD_STATE_KEY` | `LOCAL_STORAGE_WIZARD_STATE_KEY` |
| `isSimpleItemAssigned` | `isItemAssigned` |
| `createSimpleEmptyItem` | `createDefaultItem` |
| `buildSimpleModeMockOcrResponse` | `buildMockOcrResponse` |
| `data-testid="simple-wizard"` | `data-testid="workspace"` |

## Test plan

- [x] All 378 tests pass (verified by pre-push hook)
- [x] No behaviour changes — this is a pure rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)