### PR TITLE
feat: dynamic filenames for split result and PayNow QR downloads

### DIFF
--- a/src/features/split-results/logic/shareSplit.test.ts
+++ b/src/features/split-results/logic/shareSplit.test.ts
@@ -1,10 +1,46 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  buildDownloadFilename,
   buildSplitShareText,
   copyShareText,
   getShareSupport,
   shareText,
 } from '@features/split-results/logic/shareSplit';
+
+describe('buildDownloadFilename', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-19T10:00:00'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('produces prefix-date when no label is given', () => {
+    expect(buildDownloadFilename('split')).toBe('split-19-04-2026.png');
+  });
+
+  it('produces prefix-slug-date when a label is given', () => {
+    expect(buildDownloadFilename('split', 'Dinner at Raffles')).toBe(
+      'split-dinner-at-raffles-19-04-2026.png',
+    );
+  });
+
+  it('collapses consecutive special characters into a single hyphen', () => {
+    expect(buildDownloadFilename('paynow', 'Alice & Bob!!!')).toBe(
+      'paynow-alice-bob-19-04-2026.png',
+    );
+  });
+
+  it('strips leading and trailing hyphens from the slug', () => {
+    expect(buildDownloadFilename('split', '---hello---')).toBe('split-hello-19-04-2026.png');
+  });
+
+  it('uses the prefix only when label is an empty string', () => {
+    expect(buildDownloadFilename('split', '')).toBe('split-19-04-2026.png');
+  });
+});
 
 describe('buildSplitShareText', () => {
   it('formats a compact chat summary with the grand total and each person total', () => {

--- a/src/features/split-results/logic/shareSplit.ts
+++ b/src/features/split-results/logic/shareSplit.ts
@@ -65,6 +65,17 @@ export async function shareText(
   }
 }
 
+export function buildDownloadFilename(prefix: string, label?: string): string {
+  const date = new Date().toLocaleDateString('en-GB').replace(/\//g, '-');
+  const slug = label
+    ? `-${label
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '')}`
+    : '';
+  return `${prefix}${slug}-${date}.png`;
+}
+
 export function downloadImage(blob: Blob, fileName: string): void {
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement('a');

--- a/src/pages/components/workspace/shared/PersonCard.tsx
+++ b/src/pages/components/workspace/shared/PersonCard.tsx
@@ -2,6 +2,7 @@ import { formatCurrencyFromCents } from '@shared/logic/core/money';
 import { buildChargeLabel } from '@shared/logic/computation/chargeLabels';
 import type { ChargeState, Person, SplitResult } from '@shared/types';
 import { PersonAvatar } from '@pages/components/workspace/shared/PersonAvatar';
+import { buildDownloadFilename } from '@features/split-results/logic/shareSplit';
 
 interface ReceiptBreakdownEntry {
   name: string;
@@ -66,7 +67,7 @@ export function PersonCard({
             onClick={() => {
               const a = document.createElement('a');
               a.href = qrDataUrl;
-              a.download = `paynow-${person.name.toLowerCase().replace(/\s+/g, '-')}.png`;
+              a.download = buildDownloadFilename('paynow', person.name);
               a.click();
             }}
             className="cursor-pointer flex flex-col items-center gap-1.5"

--- a/src/pages/components/workspace/steps/SummaryStep.tsx
+++ b/src/pages/components/workspace/steps/SummaryStep.tsx
@@ -3,6 +3,7 @@ import type { ChargeState, Person, Receipt, SplitResult } from '@shared/types';
 import { formatCurrencyFromCents } from '@shared/logic/core/money';
 import { generateReceiptSplitImageLight } from '@features/split-results/logic/receiptSplitImageLight';
 import {
+  buildDownloadFilename,
   buildSplitShareText,
   downloadImage,
   getShareSupport,
@@ -151,7 +152,7 @@ export function SummaryStep({
         currency: displayCurrency,
         payerMobile: normalizeMobile(payerMobile) ?? undefined,
       });
-      downloadImage(blob, 'split-result.png');
+      downloadImage(blob, buildDownloadFilename('split', currentReceipt?.name));
     } catch {
       setExportError('Failed to generate image.');
     } finally {


### PR DESCRIPTION
## Summary
- Adds `buildDownloadFilename(prefix, label?)` helper in `shareSplit.ts` that builds a `prefix-slug-date.png` filename using the en-GB local date (DD-MM-YYYY)
- Split result PNG now named e.g. `split-dinner-at-raffles-19-04-2026.png` using the receipt name
- PayNow QR PNG now named e.g. `paynow-alice-19-04-2026.png` using the person's name

## Test plan
- [x] Download split result — verify filename includes receipt name slug and today's date
- [x] Download PayNow QR — verify filename includes person name and today's date
- [x] Download with no receipt name — verify filename falls back to `split-19-04-2026.png`
- [x] Multiple downloads no longer produce `split (1).png`, `split (2).png` clashes