### PR TITLE
fix: rename PayNow QR caption label from Mobile to Pay To

### DIFF
--- a/src/shared/logic/core/paynowQr.ts
+++ b/src/shared/logic/core/paynowQr.ts
@@ -44,7 +44,7 @@ function appendCaption(
   const padV = Math.round(10 * scale);
 
   const fields = [
-    { label: 'Mobile', value: mobile },
+    { label: 'Pay To', value: mobile },
     { label: 'Amount', value: `SGD ${(amountCents / 100).toFixed(2)}` },
   ];
 


### PR DESCRIPTION
## Summary
- Renames the PayNow QR caption label from 'Mobile' to 'Pay To' for clearer UX

## Test plan
- [ ] Generate a PayNow QR code and verify the caption shows 'Pay To' instead of 'Mobile'

🤖 Generated with [Claude Code](https://claude.com/claude-code)