### PR TITLE
feat(summary): show exchange rate and SGD equivalent on foreign currency person cards

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,7 @@
   "singleQuote": true,
   "trailingComma": "all",
   "printWidth": 100,
-  "tabWidth": 2
+  "tabWidth": 2,
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "tailwindStylesheet": "./src/index.css"
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "embla-carousel-react": "^8.6.0",
     "lodash-es": "^4.18.1",
     "qrcode": "^1.5.4",
     "react": "^19.2.5",
@@ -51,6 +50,7 @@
     "jsdom": "^29.0.2",
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.3",
+    "prettier-plugin-tailwindcss": "^0.7.2",
     "tailwindcss": "^4.2.2",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.58.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      embla-carousel-react:
-        specifier: ^8.6.0
-        version: 8.6.0(react@19.2.5)
       lodash-es:
         specifier: ^4.18.1
         version: 4.18.1
@@ -93,6 +90,9 @@ importers:
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
+      prettier-plugin-tailwindcss:
+        specifier: ^0.7.2
+        version: 0.7.2(prettier@3.8.3)
       tailwindcss:
         specifier: ^4.2.2
         version: 4.2.2
@@ -1046,19 +1046,6 @@ packages:
   electron-to-chromium@1.5.340:
     resolution: {integrity: sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==}
 
-  embla-carousel-react@8.6.0:
-    resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-
-  embla-carousel-reactive-utils@8.6.0:
-    resolution: {integrity: sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==}
-    peerDependencies:
-      embla-carousel: 8.6.0
-
-  embla-carousel@8.6.0:
-    resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
-
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -1549,6 +1536,61 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier-plugin-tailwindcss@0.7.2:
+    resolution: {integrity: sha512-LkphyK3Fw+q2HdMOoiEHWf93fNtYJwfamoKPl7UwtjFQdei/iIBoX11G6j706FzN3ymX9mPVi97qIY8328vdnA==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-hermes': '*'
+      '@prettier/plugin-oxc': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-hermes':
+        optional: true
+      '@prettier/plugin-oxc':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
 
   prettier@3.8.3:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
@@ -2775,18 +2817,6 @@ snapshots:
 
   electron-to-chromium@1.5.340: {}
 
-  embla-carousel-react@8.6.0(react@19.2.5):
-    dependencies:
-      embla-carousel: 8.6.0
-      embla-carousel-reactive-utils: 8.6.0(embla-carousel@8.6.0)
-      react: 19.2.5
-
-  embla-carousel-reactive-utils@8.6.0(embla-carousel@8.6.0):
-    dependencies:
-      embla-carousel: 8.6.0
-
-  embla-carousel@8.6.0: {}
-
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
@@ -3260,6 +3290,10 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier-plugin-tailwindcss@0.7.2(prettier@3.8.3):
+    dependencies:
+      prettier: 3.8.3
 
   prettier@3.8.3: {}
 

--- a/src/pages/components/workspace/BottomNav.tsx
+++ b/src/pages/components/workspace/BottomNav.tsx
@@ -28,8 +28,8 @@ export function BottomNav({
   const continueDisabled = !canContinue && !(activeStep === 'items' && itemsSubPhase === 'assign');
 
   return (
-    <footer className="fixed bottom-0 left-0 w-full z-50 bg-surface/90 backdrop-blur-xl border-t border-surface-container-highest shadow-[0_-8px_24px_rgba(25,28,29,0.06)]">
-      <div className="flex justify-between items-center px-6 md:px-10 py-3 max-w-7xl mx-auto">
+    <footer className="fixed bottom-0 left-0 z-50 w-full border-t border-surface-container-highest bg-surface/90 shadow-[0_-8px_24px_rgba(25,28,29,0.06)] backdrop-blur-xl">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-3 md:px-10">
         {/* Back */}
         {!isFirstStep && (
           <button
@@ -38,28 +38,28 @@ export function BottomNav({
             onClick={onBack}
             disabled={isFirstStep}
             className={cn(
-              'flex items-center gap-2 text-on-surface-variant px-3 py-2 hover:bg-surface-container-low rounded-xl transition-all',
-              isFirstStep && 'opacity-40 cursor-not-allowed pointer-events-none',
+              'flex items-center gap-2 rounded-xl px-3 py-2 text-on-surface-variant transition-all hover:bg-surface-container-low',
+              isFirstStep && 'pointer-events-none cursor-not-allowed opacity-40',
             )}
           >
             <span className="material-symbols-outlined text-xl">arrow_back</span>
-            <span className="text-xs font-bold tracking-widest font-label uppercase">Back</span>
+            <span className="font-label text-xs font-bold tracking-widest uppercase">Back</span>
           </button>
         )}
 
         {/* Center: grand total or context hint */}
         <div className="flex flex-col items-center">
           {grandTotalFormatted && (activeStep === 'receipt' || activeStep === 'items') ? (
-            <div className="hidden md:flex items-center gap-2">
-              <span className="text-xs font-extrabold text-on-surface-variant uppercase tracking-widest">
+            <div className="hidden items-center gap-2 md:flex">
+              <span className="text-xs font-extrabold tracking-widest text-on-surface-variant uppercase">
                 Grand Total
               </span>
-              <span className="text-base font-extrabold font-headline text-primary">
+              <span className="font-headline text-base font-extrabold text-primary">
                 {grandTotalFormatted}
               </span>
             </div>
           ) : isFirstStep ? (
-            <p className="hidden md:block text-primary text-xs font-semibold tracking-wide">
+            <p className="hidden text-xs font-semibold tracking-wide text-primary md:block">
               Add at least one person to continue
             </p>
           ) : null}
@@ -73,18 +73,18 @@ export function BottomNav({
             onClick={onNext}
             disabled={continueDisabled}
             className={cn(
-              'flex items-center gap-2 rounded-xl px-5 py-2 active:scale-95 transition-all shadow-md',
+              'flex items-center gap-2 rounded-xl px-5 py-2 shadow-md transition-all active:scale-95',
               continueDisabled
-                ? 'bg-surface-container-high text-on-surface-variant cursor-not-allowed opacity-60'
+                ? 'cursor-not-allowed bg-surface-container-high text-on-surface-variant opacity-60'
                 : isSummaryStep
                   ? 'bg-gradient-to-br from-primary to-primary-container text-on-primary shadow-primary/20'
                   : 'bg-white text-neutral-900 shadow-black/10',
             )}
           >
-            <span className="text-xs font-label uppercase tracking-wider font-bold">
+            <span className="font-label text-xs font-bold tracking-wider uppercase">
               {continueLabel}
             </span>
-            <span className="material-symbols-outlined text-xl group-hover:translate-x-1 transition-transform">
+            <span className="material-symbols-outlined text-xl transition-transform group-hover:translate-x-1">
               arrow_forward
             </span>
           </button>

--- a/src/pages/components/workspace/GeminiApiKeyModal.tsx
+++ b/src/pages/components/workspace/GeminiApiKeyModal.tsx
@@ -52,15 +52,15 @@ function GeminiApiKeyModalContent({ initialKey, onSave, onClose }: GeminiApiKeyM
       />
 
       {/* Modal card — glassmorphic */}
-      <div className="relative w-full max-w-md rounded-3xl bg-surface-container-lowest/90 backdrop-blur-[20px] shadow-[0_8px_24px_rgba(25,28,29,0.12)] border border-surface-container-highest">
+      <div className="relative w-full max-w-md rounded-3xl border border-surface-container-highest bg-surface-container-lowest/90 shadow-[0_8px_24px_rgba(25,28,29,0.12)] backdrop-blur-[20px]">
         {/* Header */}
         <div className="px-7 pt-7 pb-5">
           <div className="flex items-start justify-between gap-4">
             <div>
-              <h2 className="text-xl font-extrabold font-headline text-primary tracking-tight">
+              <h2 className="font-headline text-xl font-extrabold tracking-tight text-primary">
                 Gemini API Key
               </h2>
-              <p className="mt-1 text-sm text-on-surface-variant font-body">
+              <p className="font-body mt-1 text-sm text-on-surface-variant">
                 Required for AI-powered receipt scanning
               </p>
             </div>
@@ -68,7 +68,7 @@ function GeminiApiKeyModalContent({ initialKey, onSave, onClose }: GeminiApiKeyM
               type="button"
               onClick={onClose}
               aria-label="Close"
-              className="flex h-9 w-9 items-center justify-center rounded-xl text-on-surface-variant hover:bg-surface-container-low transition-colors"
+              className="flex h-9 w-9 items-center justify-center rounded-xl text-on-surface-variant transition-colors hover:bg-surface-container-low"
             >
               <span className="material-symbols-outlined text-xl">close</span>
             </button>
@@ -76,9 +76,9 @@ function GeminiApiKeyModalContent({ initialKey, onSave, onClose }: GeminiApiKeyM
         </div>
 
         {/* Info block + input — unified px-7 section */}
-        <div className="px-7 pb-7 space-y-5">
+        <div className="space-y-5 px-7 pb-7">
           <div className="rounded-2xl bg-surface-container-low px-5 py-4">
-            <p className="text-xs text-on-surface-variant font-body leading-relaxed">
+            <p className="font-body text-xs leading-relaxed text-on-surface-variant">
               This app uses <span className="font-semibold text-on-surface">Google Gemini</span> to
               extract line items, prices, and charges from your receipt photo. Your key is stored in
               this browser session only and used solely to call the Gemini API.
@@ -88,7 +88,7 @@ function GeminiApiKeyModalContent({ initialKey, onSave, onClose }: GeminiApiKeyM
           <div className="space-y-2">
             <label
               htmlFor="new-modal-gemini-api-key"
-              className="block text-[10px] uppercase font-extrabold font-label tracking-widest text-on-surface-variant"
+              className="font-label block text-[10px] font-extrabold tracking-widest text-on-surface-variant uppercase"
             >
               API Key
             </label>
@@ -102,15 +102,15 @@ function GeminiApiKeyModalContent({ initialKey, onSave, onClose }: GeminiApiKeyM
                 if (e.key === 'Enter') handleSave();
               }}
               placeholder="AIza…"
-              className="w-full bg-surface-container-high rounded-2xl px-5 py-2.5 text-sm font-body text-on-surface placeholder:text-outline outline-none border-2 border-transparent focus:border-primary/20 transition-all"
+              className="font-body w-full rounded-2xl border-2 border-transparent bg-surface-container-high px-5 py-2.5 text-sm text-on-surface transition-all outline-none placeholder:text-outline focus:border-primary/20"
             />
-            <p className="text-xs text-outline font-body">
+            <p className="font-body text-xs text-outline">
               Get your free key at{' '}
               <a
                 href="https://aistudio.google.com/app/api-keys"
                 target="_blank"
                 rel="noreferrer"
-                className="font-semibold text-primary underline underline-offset-2 hover:opacity-70 transition-opacity"
+                className="font-semibold text-primary underline underline-offset-2 transition-opacity hover:opacity-70"
               >
                 Google AI Studio ↗
               </a>
@@ -122,7 +122,7 @@ function GeminiApiKeyModalContent({ initialKey, onSave, onClose }: GeminiApiKeyM
             <button
               type="button"
               onClick={handleSave}
-              className="flex-1 flex items-center justify-center gap-2 rounded-xl bg-gradient-to-br from-primary to-primary-container text-on-primary px-4 py-3 text-sm font-bold font-label active:scale-[0.98] transition-transform shadow-md shadow-primary/20"
+              className="font-label flex flex-1 items-center justify-center gap-2 rounded-xl bg-gradient-to-br from-primary to-primary-container px-4 py-3 text-sm font-bold text-on-primary shadow-md shadow-primary/20 transition-transform active:scale-[0.98]"
             >
               Save &amp; Continue
               <span className="material-symbols-outlined text-base">arrow_forward</span>
@@ -130,7 +130,7 @@ function GeminiApiKeyModalContent({ initialKey, onSave, onClose }: GeminiApiKeyM
             <button
               type="button"
               onClick={onClose}
-              className="rounded-xl px-4 py-3 text-sm font-bold font-label text-on-surface hover:bg-surface-container-low transition-colors"
+              className="font-label rounded-xl px-4 py-3 text-sm font-bold text-on-surface transition-colors hover:bg-surface-container-low"
             >
               Skip
             </button>

--- a/src/pages/components/workspace/ProgressIndicator.tsx
+++ b/src/pages/components/workspace/ProgressIndicator.tsx
@@ -18,16 +18,16 @@ export function ProgressIndicator({
   // Final step shows the 4-circle connected stepper
   if (activeStep === 'final') {
     return (
-      <div className="mb-10 flex items-center justify-between max-w-2xl mx-auto">
+      <div className="mx-auto mb-10 flex max-w-2xl items-center justify-between">
         {STEP_ORDER.map((step, i) => {
           const completed = isStepCompleted(step, activeStep);
           const isCurrent = step === activeStep;
           return (
-            <div key={step} className="flex items-center flex-1">
-              <div className="flex flex-col items-center gap-2 group">
+            <div key={step} className="flex flex-1 items-center">
+              <div className="group flex flex-col items-center gap-2">
                 <div
                   className={cn(
-                    'w-10 h-10 rounded-full flex items-center justify-center font-bold transition-transform group-hover:scale-105',
+                    'flex h-10 w-10 items-center justify-center rounded-full font-bold transition-transform group-hover:scale-105',
                     completed
                       ? 'bg-secondary text-on-secondary'
                       : isCurrent
@@ -48,7 +48,7 @@ export function ProgressIndicator({
                 </div>
                 <span
                   className={cn(
-                    'text-[10px] font-bold uppercase tracking-widest',
+                    'text-[10px] font-bold tracking-widest uppercase',
                     completed
                       ? 'text-secondary'
                       : isCurrent
@@ -62,7 +62,7 @@ export function ProgressIndicator({
               {i < STEP_ORDER.length - 1 && (
                 <div
                   className={cn(
-                    'h-0.5 flex-1 mx-4',
+                    'mx-4 h-0.5 flex-1',
                     completed ? 'bg-secondary' : 'bg-surface-container-highest',
                   )}
                 />
@@ -89,21 +89,21 @@ export function ProgressIndicator({
 
   return (
     <div className="mb-10">
-      <div className="flex items-center justify-between text-on-surface-variant mb-2">
+      <div className="mb-2 flex items-center justify-between text-on-surface-variant">
         <div className="flex items-center gap-2">
-          <span className="w-8 h-8 rounded-full bg-primary text-white flex items-center justify-center font-bold text-sm">
+          <span className="flex h-8 w-8 items-center justify-center rounded-full bg-primary text-sm font-bold text-white">
             {stepNumber}
           </span>
           <span className="font-bold text-primary">{STEP_LABELS[activeStep]}</span>
           {contextText && (
-            <span className="text-xs font-medium text-on-surface-variant ml-2">{contextText}</span>
+            <span className="ml-2 text-xs font-medium text-on-surface-variant">{contextText}</span>
           )}
         </div>
         <span className="text-sm font-medium text-primary">Step {stepNumber} of 4</span>
       </div>
-      <div className="h-0.5 bg-surface-container-highest rounded-full overflow-hidden">
+      <div className="h-0.5 overflow-hidden rounded-full bg-surface-container-highest">
         <div
-          className="h-full bg-primary rounded-full transition-all duration-500"
+          className="h-full rounded-full bg-primary transition-all duration-500"
           style={{ width: `${trackFillPercent}%` }}
         />
       </div>

--- a/src/pages/components/workspace/TopAppBar.tsx
+++ b/src/pages/components/workspace/TopAppBar.tsx
@@ -35,15 +35,15 @@ export function TopAppBar({
   }
 
   return (
-    <header className="bg-surface/80 backdrop-blur-md sticky top-0 z-40 border-b border-surface-container-highest">
-      <div className="flex items-center w-full px-6 md:px-8 py-4 max-w-7xl mx-auto gap-6">
+    <header className="sticky top-0 z-40 border-b border-surface-container-highest bg-surface/80 backdrop-blur-md">
+      <div className="mx-auto flex w-full max-w-7xl items-center gap-6 px-6 py-4 md:px-8">
         {/* Logo */}
-        <div className="text-2xl font-bold text-primary tracking-tight font-headline shrink-0">
+        <div className="font-headline shrink-0 text-2xl font-bold tracking-tight text-primary">
           Split
         </div>
 
         {/* Desktop: connected step circles */}
-        <nav className="hidden md:flex items-center flex-1 justify-center">
+        <nav className="hidden flex-1 items-center justify-center md:flex">
           {STEP_ORDER.map((step, i) => {
             const completed = i < stepIndex;
             const isCurrent = step === activeStep;
@@ -52,7 +52,7 @@ export function TopAppBar({
                 <div className="flex flex-col items-center gap-1">
                   <div
                     className={cn(
-                      'w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold transition-all',
+                      'flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold transition-all',
                       completed
                         ? 'bg-secondary text-on-secondary'
                         : isCurrent
@@ -73,7 +73,7 @@ export function TopAppBar({
                   </div>
                   <span
                     className={cn(
-                      'text-[9px] font-bold uppercase tracking-widest',
+                      'text-[9px] font-bold tracking-widest uppercase',
                       completed
                         ? 'text-secondary'
                         : isCurrent
@@ -87,7 +87,7 @@ export function TopAppBar({
                 {i < STEP_ORDER.length - 1 && (
                   <div
                     className={cn(
-                      'h-0.5 w-12 mx-2 mb-4',
+                      'mx-2 mb-4 h-0.5 w-12',
                       completed ? 'bg-secondary' : 'bg-surface-container-highest',
                     )}
                   />
@@ -99,10 +99,10 @@ export function TopAppBar({
 
         {/* Right: "STEP X: LABEL" on mobile, step count on desktop */}
         <div data-testid="wizard-step-context" className="ml-auto shrink-0 text-right">
-          <p className="text-xs font-bold text-on-surface-variant uppercase tracking-widest md:hidden">
+          <p className="text-xs font-bold tracking-widest text-on-surface-variant uppercase md:hidden">
             Step {stepNumber}: {STEP_LABELS[activeStep]}
           </p>
-          <p className="hidden md:block text-xs font-bold text-primary uppercase tracking-widest">
+          <p className="hidden text-xs font-bold tracking-widest text-primary uppercase md:block">
             Step {stepNumber} of {STEP_ORDER.length}
           </p>
           {contextText && <p className="text-[10px] text-on-surface-variant">{contextText}</p>}
@@ -114,16 +114,16 @@ export function TopAppBar({
           target="_blank"
           rel="noopener noreferrer"
           aria-label="View source on GitHub"
-          className="text-on-surface-variant hover:text-primary transition-colors shrink-0"
+          className="shrink-0 text-on-surface-variant transition-colors hover:text-primary"
         >
-          <svg viewBox="0 0 24 24" fill="currentColor" className="w-4 h-4">
+          <svg viewBox="0 0 24 24" fill="currentColor" className="h-4 w-4">
             <path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.385-1.335-1.755-1.335-1.755-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 21.795 24 17.295 24 12c0-6.63-5.37-12-12-12z" />
           </svg>
         </a>
       </div>
 
       {/* Mobile: thin progress bar */}
-      <div className="md:hidden h-0.5 bg-surface-container-highest">
+      <div className="h-0.5 bg-surface-container-highest md:hidden">
         <div
           className="h-full bg-primary transition-all duration-500"
           style={{ width: `${trackFillPercent}%` }}

--- a/src/pages/components/workspace/Workspace.tsx
+++ b/src/pages/components/workspace/Workspace.tsx
@@ -128,7 +128,7 @@ export function Workspace() {
 
   return (
     <div
-      className="bg-surface text-on-surface font-body min-h-screen flex flex-col"
+      className="font-body flex min-h-screen flex-col bg-surface text-on-surface"
       data-testid="workspace"
     >
       <TopAppBar
@@ -138,7 +138,7 @@ export function Workspace() {
         detectedItemsCount={detectedItemsCount}
       />
 
-      <main className="flex-grow max-w-7xl mx-auto w-full px-6 md:px-8 pt-4 md:pt-10 pb-48">
+      <main className="mx-auto w-full max-w-7xl flex-grow px-6 pt-4 pb-48 md:px-8 md:pt-10">
         {activeStep === 'people' && (
           <PeopleStep
             people={people}

--- a/src/pages/components/workspace/shared/ChargeToggle.tsx
+++ b/src/pages/components/workspace/shared/ChargeToggle.tsx
@@ -21,20 +21,20 @@ export function ChargeToggle({ label, value, onChange }: Props) {
             aria-checked={isEnabled}
             onClick={() => onChange({ ...value, enabled: !isEnabled })}
             className={cn(
-              'w-10 h-6 rounded-full relative p-1 cursor-pointer transition-colors flex-shrink-0',
+              'relative h-6 w-10 flex-shrink-0 cursor-pointer rounded-full p-1 transition-colors',
               isEnabled ? 'bg-primary' : 'bg-surface-container-highest',
             )}
           >
             <div
               className={cn(
-                'w-4 h-4 bg-on-primary rounded-full transition-transform shadow-sm',
+                'h-4 w-4 rounded-full bg-on-primary shadow-sm transition-transform',
                 isEnabled ? 'translate-x-4' : 'translate-x-0',
               )}
             />
           </button>
           <span
             className={cn(
-              'font-bold text-sm',
+              'text-sm font-bold',
               isEnabled ? 'text-on-surface' : 'text-on-surface-variant',
             )}
           >
@@ -45,7 +45,7 @@ export function ChargeToggle({ label, value, onChange }: Props) {
         {/* $/% mode toggle */}
         <div
           className={cn(
-            'flex items-center bg-surface-container-low rounded-lg p-1',
+            'flex items-center rounded-lg bg-surface-container-low p-1',
             !isEnabled && 'opacity-50',
           )}
         >
@@ -53,9 +53,9 @@ export function ChargeToggle({ label, value, onChange }: Props) {
             type="button"
             onClick={() => isEnabled && onChange({ ...value, mode: 'amount' as ChargeMode })}
             className={cn(
-              'px-2 py-0.5 rounded-md text-[10px] font-extrabold transition-all',
+              'rounded-md px-2 py-0.5 text-[10px] font-extrabold transition-all',
               value.mode === 'amount'
-                ? 'bg-surface-container-lowest shadow-sm text-primary'
+                ? 'bg-surface-container-lowest text-primary shadow-sm'
                 : 'text-on-surface-variant',
             )}
           >
@@ -65,9 +65,9 @@ export function ChargeToggle({ label, value, onChange }: Props) {
             type="button"
             onClick={() => isEnabled && onChange({ ...value, mode: 'percent' as ChargeMode })}
             className={cn(
-              'px-2 py-0.5 rounded-md text-[10px] font-extrabold transition-all',
+              'rounded-md px-2 py-0.5 text-[10px] font-extrabold transition-all',
               value.mode === 'percent'
-                ? 'bg-surface-container-lowest shadow-sm text-primary'
+                ? 'bg-surface-container-lowest text-primary shadow-sm'
                 : 'text-on-surface-variant',
             )}
           >
@@ -78,7 +78,7 @@ export function ChargeToggle({ label, value, onChange }: Props) {
 
       {isEnabled && (
         <div className="relative">
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-primary font-bold text-xs">
+          <span className="absolute top-1/2 left-3 -translate-y-1/2 text-xs font-bold text-primary">
             {value.mode === 'amount' ? '$' : '%'}
           </span>
           <input
@@ -93,7 +93,7 @@ export function ChargeToggle({ label, value, onChange }: Props) {
               )
             }
             placeholder={value.mode === 'amount' ? '0.00' : '0'}
-            className="w-full bg-surface-container-low border-none rounded-xl py-3 pl-7 pr-3 text-sm font-bold text-primary focus:ring-1 focus:ring-primary/20 outline-none"
+            className="w-full rounded-xl border-none bg-surface-container-low py-3 pr-3 pl-7 text-sm font-bold text-primary outline-none focus:ring-1 focus:ring-primary/20"
           />
         </div>
       )}

--- a/src/pages/components/workspace/shared/CurrencySelector.tsx
+++ b/src/pages/components/workspace/shared/CurrencySelector.tsx
@@ -11,7 +11,7 @@ export function CurrencySelector({ value, onChange, className }: Props) {
     <select
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      className={`bg-surface-container border border-outline-variant/40 rounded-lg px-2 py-1 text-sm font-semibold text-on-surface focus:outline-none focus:ring-2 focus:ring-primary/40 cursor-pointer ${className ?? ''}`}
+      className={`cursor-pointer rounded-lg border border-outline-variant/40 bg-surface-container px-2 py-1 text-sm font-semibold text-on-surface focus:ring-2 focus:ring-primary/40 focus:outline-none ${className ?? ''}`}
     >
       {SUPPORTED_CURRENCIES.map((code) => (
         <option key={code} value={code}>

--- a/src/pages/components/workspace/shared/ExchangeRateDisplay.tsx
+++ b/src/pages/components/workspace/shared/ExchangeRateDisplay.tsx
@@ -107,20 +107,20 @@ export function ExchangeRateDisplay({ receiptId, currency, exchangeRateOverride 
       </span>
       {isOverridden ? (
         <>
-          <span className="bg-warning/20 text-warning-container px-1.5 py-0.5 rounded text-xs font-semibold">
+          <span className="bg-warning/20 text-warning-container rounded px-1.5 py-0.5 text-xs font-semibold">
             Manual
           </span>
           <button
             type="button"
             onClick={resetToAuto}
-            className="text-xs text-on-surface-variant hover:text-primary transition-colors"
+            className="text-xs text-on-surface-variant transition-colors hover:text-primary"
             title="Reset to auto rate"
           >
             <span className="material-symbols-outlined text-sm">refresh</span>
           </button>
         </>
       ) : (
-        <span className="bg-secondary-container/50 text-on-secondary-container px-1.5 py-0.5 rounded text-xs font-semibold">
+        <span className="rounded bg-secondary-container/50 px-1.5 py-0.5 text-xs font-semibold text-on-secondary-container">
           Auto
         </span>
       )}

--- a/src/pages/components/workspace/shared/GlobalChargesPanel.tsx
+++ b/src/pages/components/workspace/shared/GlobalChargesPanel.tsx
@@ -35,12 +35,12 @@ export function GlobalChargesPanel({
   currency,
 }: Props) {
   return (
-    <div className="bg-surface-container-lowest p-8 rounded-3xl shadow-lg border border-surface-container-highest sticky top-24">
-      <h3 className="text-xl font-bold font-headline text-primary mb-8 border-b border-surface-container-high pb-4">
+    <div className="sticky top-24 rounded-3xl border border-surface-container-highest bg-surface-container-lowest p-8 shadow-lg">
+      <h3 className="font-headline mb-8 border-b border-surface-container-high pb-4 text-xl font-bold text-primary">
         Global Charges
       </h3>
 
-      <div className="space-y-6 mb-10">
+      <div className="mb-10 space-y-6">
         <ChargeToggle label="GST / Tax" value={gst} onChange={onGstChange} />
         <ChargeToggle
           label="Service Charge"
@@ -63,12 +63,12 @@ export function GlobalChargesPanel({
         <div>
           <label
             htmlFor="receipt-total-new"
-            className="block text-[10px] uppercase font-extrabold text-on-surface-variant tracking-widest mb-2 font-label"
+            className="font-label mb-2 block text-[10px] font-extrabold tracking-widest text-on-surface-variant uppercase"
           >
             Receipt Total (Override)
           </label>
           <div className="relative">
-            <span className="absolute left-4 top-1/2 -translate-y-1/2 text-on-surface-variant font-bold">
+            <span className="absolute top-1/2 left-4 -translate-y-1/2 font-bold text-on-surface-variant">
               {getCurrencySymbol(currency ?? BASE_CURRENCY)}
             </span>
             <input
@@ -79,7 +79,7 @@ export function GlobalChargesPanel({
               value={receiptTotalInput}
               onChange={(e) => onReceiptTotalInputChange(e.target.value)}
               placeholder="0.00"
-              className="w-full bg-surface-container-high pl-12 border-2 border-transparent focus:border-primary/20 rounded-2xl py-5 pl-8 pr-4 text-3xl font-extrabold font-headline text-on-surface transition-all outline-none"
+              className="font-headline w-full rounded-2xl border-2 border-transparent bg-surface-container-high py-5 pr-4 pl-8 pl-12 text-3xl font-extrabold text-on-surface transition-all outline-none focus:border-primary/20"
             />
           </div>
         </div>

--- a/src/pages/components/workspace/shared/LineItemCard.tsx
+++ b/src/pages/components/workspace/shared/LineItemCard.tsx
@@ -34,18 +34,18 @@ export function LineItemCard({
   const discountVisible = showDiscount || !!item.discountPercentInput;
 
   return (
-    <div className="bg-surface-container-lowest px-3 py-2.5 rounded-xl shadow-sm border border-surface-container-highest hover:border-primary/20 transition-all group relative">
+    <div className="group relative rounded-xl border border-surface-container-highest bg-surface-container-lowest px-3 py-2.5 shadow-sm transition-all hover:border-primary/20">
       {/* Name + Price row */}
-      <div className="flex justify-between items-center gap-3">
+      <div className="flex items-center justify-between gap-3">
         <input
           type="text"
           value={item.name}
           onChange={(e) => onUpdate((current) => ({ ...current, name: e.target.value }))}
           placeholder="Item name"
-          className="bg-transparent border-none p-0 focus:ring-0 font-medium text-on-surface w-full text-base outline-none placeholder:text-outline"
+          className="w-full border-none bg-transparent p-0 text-base font-medium text-on-surface outline-none placeholder:text-outline focus:ring-0"
         />
-        <div className="flex items-center gap-2 flex-shrink-0">
-          <div className="flex items-center gap-1 bg-surface-container rounded-lg px-2 py-1">
+        <div className="flex flex-shrink-0 items-center gap-2">
+          <div className="flex items-center gap-1 rounded-lg bg-surface-container px-2 py-1">
             <span className="text-xs font-bold text-on-surface-variant">{currencySymbol}</span>
             <input
               type="text"
@@ -53,14 +53,14 @@ export function LineItemCard({
               value={item.amountInput}
               onChange={(e) => onUpdate((current) => ({ ...current, amountInput: e.target.value }))}
               placeholder="0.00"
-              className="bg-transparent border-none p-0 focus:ring-0 font-bold text-primary w-16 text-right text-base outline-none placeholder:text-outline"
+              className="w-16 border-none bg-transparent p-0 text-right text-base font-bold text-primary outline-none placeholder:text-outline focus:ring-0"
             />
           </div>
           <button
             type="button"
             onClick={onRemove}
             aria-label="Remove item"
-            className="flex items-center justify-center text-error opacity-40 hover:opacity-100 transition-opacity"
+            className="flex items-center justify-center text-error opacity-40 transition-opacity hover:opacity-100"
           >
             <span className="material-symbols-outlined !text-base">close</span>
           </button>
@@ -71,11 +71,11 @@ export function LineItemCard({
       {discountVisible && (
         <div className="mt-2 flex items-center justify-between gap-2">
           <div className="flex items-center gap-1.5">
-            <span className="material-symbols-outlined text-secondary text-sm">loyalty</span>
+            <span className="material-symbols-outlined text-sm text-secondary">loyalty</span>
             <span className="text-xs font-bold text-secondary">Discount</span>
           </div>
           <div className="flex items-center gap-2">
-            <div className="flex items-center bg-surface-container rounded border border-secondary-container/50 px-1.5 py-0.5">
+            <div className="flex items-center rounded border border-secondary-container/50 bg-surface-container px-1.5 py-0.5">
               <input
                 ref={discountInputRef}
                 type="text"
@@ -85,15 +85,15 @@ export function LineItemCard({
                   onUpdate((current) => ({ ...current, discountPercentInput: e.target.value }))
                 }
                 placeholder="0"
-                className="bg-transparent border-none p-0 focus:ring-0 font-bold text-secondary w-8 text-right text-xs outline-none"
+                className="w-8 border-none bg-transparent p-0 text-right text-xs font-bold text-secondary outline-none focus:ring-0"
               />
-              <span className="text-[10px] font-bold text-secondary ml-0.5">%</span>
+              <span className="ml-0.5 text-[10px] font-bold text-secondary">%</span>
             </div>
             <button
               type="button"
               onClick={handleHideDiscount}
               aria-label="Remove discount"
-              className="flex items-center justify-center text-error opacity-40 hover:opacity-100 transition-opacity"
+              className="flex items-center justify-center text-error opacity-40 transition-opacity hover:opacity-100"
             >
               <span className="material-symbols-outlined !text-base">close</span>
             </button>
@@ -102,19 +102,19 @@ export function LineItemCard({
       )}
 
       {/* Footer */}
-      <div className="flex items-center justify-between mt-1.5">
+      <div className="mt-1.5 flex items-center justify-between">
         {!discountVisible && (
           <button
             type="button"
             onClick={handleShowDiscount}
-            className="flex items-center gap-0.5 text-[10px] font-semibold text-on-surface-variant hover:text-primary transition-colors"
+            className="flex items-center gap-0.5 text-[10px] font-semibold text-on-surface-variant transition-colors hover:text-primary"
           >
             <span className="material-symbols-outlined text-xs">add</span>
             <span>Discount</span>
           </button>
         )}
         {discount.enabled && (
-          <span className="text-[10px] text-on-surface-variant italic ml-auto">
+          <span className="ml-auto text-[10px] text-on-surface-variant italic">
             {discount.mode === 'percent'
               ? `${discount.percentInput || '0'}% bill discount`
               : 'Bill discount'}{' '}

--- a/src/pages/components/workspace/shared/PersonAvatar.tsx
+++ b/src/pages/components/workspace/shared/PersonAvatar.tsx
@@ -13,7 +13,7 @@ export function PersonAvatar({ name, colorIndex, size = 'md' }: Props) {
 
   return (
     <div
-      className={`${sizeClasses} rounded-full flex items-center justify-center font-bold flex-shrink-0`}
+      className={`${sizeClasses} flex flex-shrink-0 items-center justify-center rounded-full font-bold`}
       style={{ backgroundColor: color.avatarBg, color: color.avatarText }}
     >
       {initial}

--- a/src/pages/components/workspace/shared/PersonCard.tsx
+++ b/src/pages/components/workspace/shared/PersonCard.tsx
@@ -3,11 +3,13 @@ import { buildChargeLabel } from '@shared/logic/computation/chargeLabels';
 import type { ChargeState, Person, SplitResult } from '@shared/types';
 import { PersonAvatar } from '@pages/components/workspace/shared/PersonAvatar';
 import { buildDownloadFilename } from '@features/split-results/logic/shareSplit';
+import { BASE_CURRENCY } from '@shared/constants';
 
 interface ReceiptBreakdownEntry {
   name: string;
   split: SplitResult;
   currency?: string;
+  effectiveRate?: number;
 }
 
 interface Props {
@@ -20,6 +22,8 @@ interface Props {
   showDetails?: boolean;
   receiptBreakdown?: ReceiptBreakdownEntry[];
   currency?: string;
+  conversionRate?: number;
+  fromCurrency?: string;
   qrDataUrl?: string;
 }
 
@@ -33,6 +37,8 @@ export function PersonCard({
   showDetails = false,
   receiptBreakdown,
   currency,
+  conversionRate,
+  fromCurrency,
   qrDataUrl,
 }: Props) {
   const lines = split.lineItemsByPerson[person.id] ?? [];
@@ -42,26 +48,36 @@ export function PersonCard({
   const gstAmt = split.gstByPersonCents[person.id] ?? 0;
 
   return (
-    <div className="bg-surface-container-lowest rounded-2xl p-6 flex flex-col h-full">
+    <div className="flex h-full flex-col rounded-2xl bg-surface-container-lowest p-6">
       {/* Header */}
-      <div className="flex justify-between items-start mb-4">
+      <div className="mb-4 flex items-start justify-between">
         <div className="flex items-center gap-3">
           <PersonAvatar name={person.name} colorIndex={colorIndex} />
           <h3 className="text-2xl font-bold text-primary">{person.name}</h3>
         </div>
         <div className="text-right">
-          <span className="text-[10px] uppercase font-semibold tracking-widest text-on-surface-variant block leading-none mb-1">
-            {receiptBreakdown ? 'Total Consolidated' : 'Total Due'}
+          <span className="mb-1 block text-[10px] leading-none font-semibold tracking-widest text-on-surface-variant uppercase">
+            {receiptBreakdown ? 'Grand Total Due' : 'Total Due'}
           </span>
-          <p className="text-3xl font-semibold text-on-surface leading-none font-headline">
+          <p className="font-headline text-3xl leading-none font-semibold text-on-surface">
             {formatCurrencyFromCents(total, currency)}
           </p>
+          {conversionRate !== undefined && fromCurrency !== undefined && (
+            <>
+              <span className="mt-1 block text-xs text-on-surface-variant">
+                ≈ {formatCurrencyFromCents(Math.round(total * conversionRate), BASE_CURRENCY)}
+              </span>
+              <span className="block text-xs text-on-surface-variant">
+                1 {BASE_CURRENCY} = {parseFloat((1 / conversionRate).toFixed(5))} {fromCurrency}
+              </span>
+            </>
+          )}
         </div>
       </div>
 
       {/* PayNow QR — centered below header */}
       {qrDataUrl && (
-        <div className="flex flex-col items-center mb-4 gap-1.5">
+        <div className="mb-4 flex flex-col items-center gap-1.5">
           <button
             type="button"
             onClick={() => {
@@ -70,12 +86,12 @@ export function PersonCard({
               a.download = buildDownloadFilename('paynow', person.name);
               a.click();
             }}
-            className="cursor-pointer flex flex-col items-center gap-1.5"
+            className="flex cursor-pointer flex-col items-center gap-1.5"
           >
             <img
               src={qrDataUrl}
               alt={`PayNow QR for ${person.name}`}
-              className="w-40 h-auto rounded-xl border border-outline-variant/20"
+              className="h-auto w-40 rounded-xl border border-outline-variant/20"
             />
             <span className="flex items-center gap-1 text-xs text-on-surface-variant">
               <span className="material-symbols-outlined text-sm">download</span>
@@ -87,7 +103,7 @@ export function PersonCard({
 
       {/* Receipt totals summary (collapsed view) */}
       {!showDetails && receiptBreakdown && receiptBreakdown.length > 0 && (
-        <div className="space-y-1.5 mt-2">
+        <div className="mt-2 space-y-1.5">
           {receiptBreakdown.map((entry) => {
             const entryLines = (entry.split.lineItemsByPerson[person.id] ?? []).filter(
               (l) => l.involved,
@@ -114,7 +130,7 @@ export function PersonCard({
 
       {/* Itemized shares */}
       {showDetails && (
-        <div className="space-y-3 flex-grow mt-2">
+        <div className="mt-2 flex-grow space-y-3">
           {receiptBreakdown ? (
             // Multi-receipt: each receipt as its own card
             receiptBreakdown.length === 0 ? (
@@ -135,24 +151,41 @@ export function PersonCard({
                   if (entryLines.length === 0) return null;
 
                   return (
-                    <div key={entry.name} className="bg-surface-container-low rounded-xl p-5">
-                      <div className="flex justify-between items-baseline mb-4">
+                    <div key={entry.name} className="rounded-xl bg-surface-container-low p-5">
+                      <div className="mb-4 flex items-start justify-between">
                         <span className="text-base font-bold text-on-surface">{entry.name}</span>
-                        <span className="text-base font-bold text-on-surface">
-                          {formatCurrencyFromCents(entrySubtotalCents, entry.currency)}
-                        </span>
+                        <div className="text-right">
+                          <span className="block text-base font-bold text-on-surface">
+                            {formatCurrencyFromCents(entrySubtotalCents, entry.currency)}
+                          </span>
+                          {entry.effectiveRate !== undefined && (
+                            <>
+                              <span className="mt-0.5 block text-xs text-on-surface-variant">
+                                ≈{' '}
+                                {formatCurrencyFromCents(
+                                  Math.round(entrySubtotalCents * entry.effectiveRate),
+                                  BASE_CURRENCY,
+                                )}
+                              </span>
+                              <span className="block text-xs text-on-surface-variant">
+                                1 {BASE_CURRENCY} ={' '}
+                                {parseFloat((1 / entry.effectiveRate).toFixed(5))} {entry.currency}
+                              </span>
+                            </>
+                          )}
+                        </div>
                       </div>
-                      <div className="border-t border-outline-variant/15 pt-3 space-y-3">
+                      <div className="space-y-3 border-t border-outline-variant/15 pt-3">
                         {entryLines.map((line, i) => (
                           <div
                             key={`${line.itemId}-${i}`}
-                            className="flex justify-between text-base pl-4"
+                            className="flex justify-between pl-4 text-base"
                           >
                             <span
                               className={
                                 line.involved
-                                  ? 'text-on-surface-variant truncate pr-4'
-                                  : 'text-on-surface-variant/40 truncate pr-4 italic'
+                                  ? 'truncate pr-4 text-on-surface-variant'
+                                  : 'truncate pr-4 text-on-surface-variant/40 italic'
                               }
                             >
                               {line.name}
@@ -160,8 +193,8 @@ export function PersonCard({
                             <span
                               className={
                                 line.involved
-                                  ? 'text-on-surface-variant flex-shrink-0'
-                                  : 'text-on-surface-variant/40 flex-shrink-0 italic'
+                                  ? 'flex-shrink-0 text-on-surface-variant'
+                                  : 'flex-shrink-0 text-on-surface-variant/40 italic'
                               }
                             >
                               {line.involved
@@ -174,7 +207,7 @@ export function PersonCard({
                           <>
                             <div className="border-t border-outline-variant/40" />
                             {entryDiscountAmt > 0 && (
-                              <div className="flex justify-between text-base pl-4">
+                              <div className="flex justify-between pl-4 text-base">
                                 <span className="text-on-surface-variant italic">
                                   {buildChargeLabel('Discount', discount)}
                                 </span>
@@ -184,7 +217,7 @@ export function PersonCard({
                               </div>
                             )}
                             {entryServiceAmt > 0 && (
-                              <div className="flex justify-between text-base pl-4">
+                              <div className="flex justify-between pl-4 text-base">
                                 <span className="text-on-surface-variant italic">
                                   {buildChargeLabel('Service Charge', serviceCharge)}
                                 </span>
@@ -194,7 +227,7 @@ export function PersonCard({
                               </div>
                             )}
                             {entryGstAmt > 0 && (
-                              <div className="flex justify-between text-base pl-4">
+                              <div className="flex justify-between pl-4 text-base">
                                 <span className="text-on-surface-variant italic">
                                   {buildChargeLabel('GST / Tax', gst)}
                                 </span>
@@ -213,7 +246,7 @@ export function PersonCard({
             )
           ) : (
             // Single receipt: card with items + charges
-            <div className="bg-surface-container-low rounded-xl p-5">
+            <div className="rounded-xl bg-surface-container-low p-5">
               {lines.length === 0 ? (
                 <p className="text-sm text-on-surface-variant italic">No items assigned.</p>
               ) : (
@@ -221,13 +254,13 @@ export function PersonCard({
                   {lines.map((line, i) => (
                     <div
                       key={`${line.itemId}-${i}`}
-                      className="flex justify-between text-base pl-4"
+                      className="flex justify-between pl-4 text-base"
                     >
                       <span
                         className={
                           line.involved
-                            ? 'text-on-surface-variant truncate pr-4'
-                            : 'text-on-surface-variant/40 truncate pr-4 italic'
+                            ? 'truncate pr-4 text-on-surface-variant'
+                            : 'truncate pr-4 text-on-surface-variant/40 italic'
                         }
                       >
                         {line.name}
@@ -235,8 +268,8 @@ export function PersonCard({
                       <span
                         className={
                           line.involved
-                            ? 'text-on-surface-variant flex-shrink-0'
-                            : 'text-on-surface-variant/40 flex-shrink-0 italic'
+                            ? 'flex-shrink-0 text-on-surface-variant'
+                            : 'flex-shrink-0 text-on-surface-variant/40 italic'
                         }
                       >
                         {line.involved
@@ -246,9 +279,9 @@ export function PersonCard({
                     </div>
                   ))}
                   {(serviceAmt > 0 || gstAmt > 0 || discountAmt > 0) && (
-                    <div className="border-t border-outline-variant/15 pt-3 space-y-3">
+                    <div className="space-y-3 border-t border-outline-variant/15 pt-3">
                       {discountAmt > 0 && (
-                        <div className="flex justify-between text-base pl-4">
+                        <div className="flex justify-between pl-4 text-base">
                           <span className="text-on-surface-variant italic">
                             {buildChargeLabel('Discount', discount)}
                           </span>
@@ -258,7 +291,7 @@ export function PersonCard({
                         </div>
                       )}
                       {serviceAmt > 0 && (
-                        <div className="flex justify-between text-base pl-4">
+                        <div className="flex justify-between pl-4 text-base">
                           <span className="text-on-surface-variant italic">
                             {buildChargeLabel('Service', serviceCharge)}
                           </span>
@@ -268,7 +301,7 @@ export function PersonCard({
                         </div>
                       )}
                       {gstAmt > 0 && (
-                        <div className="flex justify-between text-base pl-4">
+                        <div className="flex justify-between pl-4 text-base">
                           <span className="text-on-surface-variant italic">
                             {buildChargeLabel('GST / Tax', gst)}
                           </span>

--- a/src/pages/components/workspace/shared/ReceiptImportActions.tsx
+++ b/src/pages/components/workspace/shared/ReceiptImportActions.tsx
@@ -66,17 +66,17 @@ export function ReceiptImportActions({
   return (
     <div
       className={cn(
-        'p-6 bg-surface-container-lowest rounded-2xl shadow-sm space-y-4 border border-outline-variant/20',
+        'space-y-4 rounded-2xl border border-outline-variant/20 bg-surface-container-lowest p-6 shadow-sm',
         receiptFile && !hasApiKey && 'ring-2 ring-error',
       )}
     >
-      <h4 className="text-xs font-bold text-on-surface-variant uppercase tracking-widest">
+      <h4 className="text-xs font-bold tracking-widest text-on-surface-variant uppercase">
         Scan Receipt
       </h4>
 
       <div className="grid grid-cols-2 gap-3">
-        <label className="flex flex-col items-center justify-center p-4 bg-surface-container-low rounded-xl hover:bg-surface-container-high transition-colors cursor-pointer">
-          <span className="material-symbols-outlined text-primary mb-2">upload_file</span>
+        <label className="flex cursor-pointer flex-col items-center justify-center rounded-xl bg-surface-container-low p-4 transition-colors hover:bg-surface-container-high">
+          <span className="material-symbols-outlined mb-2 text-primary">upload_file</span>
           <span className="text-[10px] font-bold text-primary">UPLOAD</span>
           <input
             ref={fileInputRef}
@@ -87,8 +87,8 @@ export function ReceiptImportActions({
             onChange={handleFileChange}
           />
         </label>
-        <label className="flex flex-col items-center justify-center p-4 bg-surface-container-low rounded-xl hover:bg-surface-container-high transition-colors cursor-pointer">
-          <span className="material-symbols-outlined text-primary mb-2">photo_camera</span>
+        <label className="flex cursor-pointer flex-col items-center justify-center rounded-xl bg-surface-container-low p-4 transition-colors hover:bg-surface-container-high">
+          <span className="material-symbols-outlined mb-2 text-primary">photo_camera</span>
           <span className="text-[10px] font-bold text-primary">CAPTURE</span>
           <input
             ref={cameraInputRef}
@@ -102,18 +102,18 @@ export function ReceiptImportActions({
       </div>
 
       {receiptFile && (
-        <div className="pt-3 border-t border-surface-container-high space-y-3">
+        <div className="space-y-3 border-t border-surface-container-high pt-3">
           <div className="flex items-center gap-2 text-xs text-on-surface-variant">
             {previewUrl ? (
               <button
                 type="button"
                 onClick={() => setIsFullscreen(true)}
-                className="w-8 h-8 rounded-lg overflow-hidden flex-shrink-0 cursor-pointer ring-1 ring-outline-variant/30 hover:ring-primary hover:ring-2 transition-all"
+                className="h-8 w-8 flex-shrink-0 cursor-pointer overflow-hidden rounded-lg ring-1 ring-outline-variant/30 transition-all hover:ring-2 hover:ring-primary"
               >
                 <img
                   src={previewUrl}
                   alt="Receipt preview"
-                  className="w-full h-full object-cover"
+                  className="h-full w-full object-cover"
                 />
               </button>
             ) : (
@@ -123,7 +123,7 @@ export function ReceiptImportActions({
               type="button"
               onClick={() => setIsFullscreen(true)}
               aria-label={`Open fullscreen preview of ${receiptFile.name}`}
-              className="truncate flex-1 text-left cursor-pointer hover:text-primary transition-colors"
+              className="flex-1 cursor-pointer truncate text-left transition-colors hover:text-primary"
             >
               {receiptFile.name}
             </button>
@@ -134,7 +134,7 @@ export function ReceiptImportActions({
                 onReceiptFileSelected(null);
               }}
               aria-label="Remove upload"
-              className="flex-shrink-0 text-on-surface-variant hover:text-error transition-colors cursor-pointer"
+              className="flex-shrink-0 cursor-pointer text-on-surface-variant transition-colors hover:text-error"
             >
               <span className="material-symbols-outlined text-sm">close</span>
             </button>
@@ -160,7 +160,7 @@ export function ReceiptImportActions({
               type="button"
               onClick={() => setShowApiKeyModal(true)}
               className={cn(
-                'text-xs font-bold underline cursor-pointer',
+                'cursor-pointer text-xs font-bold underline',
                 hasApiKey ? 'text-on-surface-variant hover:text-primary' : 'text-error',
               )}
             >
@@ -173,9 +173,9 @@ export function ReceiptImportActions({
             onClick={onScanReceipt}
             disabled={scan.isScanning || !hasApiKey}
             className={cn(
-              'w-full flex items-center justify-center gap-2 py-3 rounded-xl font-bold text-sm transition-all active:scale-95',
+              'flex w-full items-center justify-center gap-2 rounded-xl py-3 text-sm font-bold transition-all active:scale-95',
               scan.isScanning || !hasApiKey
-                ? 'bg-surface-container-high text-on-surface-variant cursor-not-allowed opacity-50'
+                ? 'cursor-not-allowed bg-surface-container-high text-on-surface-variant opacity-50'
                 : 'bg-gradient-to-br from-primary to-primary-container text-on-primary shadow-lg shadow-primary/20',
             )}
           >
@@ -185,21 +185,21 @@ export function ReceiptImportActions({
             {scan.isScanning ? scan.loadingMessage || 'Scanning…' : 'Scan Receipt'}
           </button>
           {scan.scanStatus && !scan.isScanning && (
-            <p className="text-xs text-secondary font-medium">{scan.scanStatus}</p>
+            <p className="text-xs font-medium text-secondary">{scan.scanStatus}</p>
           )}
-          {scan.scanError && <p className="text-xs text-error font-medium">{scan.scanError}</p>}
+          {scan.scanError && <p className="text-xs font-medium text-error">{scan.scanError}</p>}
         </div>
       )}
 
       {mockReceipts.length > 0 && (
-        <div className="pt-3 border-t border-surface-container-high flex items-center gap-2 flex-wrap">
+        <div className="flex flex-wrap items-center gap-2 border-t border-surface-container-high pt-3">
           {mockReceipts.map(({ onLoad }, i) => (
             <button
               key={i}
               type="button"
               data-testid={`load-mock-receipt-btn-${i}`}
               onClick={onLoad}
-              className="px-2.5 py-1 rounded-lg bg-surface-container-low text-[10px] font-semibold text-on-surface-variant hover:bg-surface-container hover:text-primary transition-colors uppercase tracking-wide"
+              className="rounded-lg bg-surface-container-low px-2.5 py-1 text-[10px] font-semibold tracking-wide text-on-surface-variant uppercase transition-colors hover:bg-surface-container hover:text-primary"
             >
               Load Mock Receipt {i + 1}
             </button>
@@ -212,14 +212,14 @@ export function ReceiptImportActions({
           role="dialog"
           aria-modal="true"
           aria-label="Receipt image preview"
-          className="fixed inset-0 z-50 bg-black/70 flex items-center justify-center"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
           onClick={() => setIsFullscreen(false)}
         >
           <button
             type="button"
             autoFocus
             onClick={() => setIsFullscreen(false)}
-            className="absolute top-4 right-4 z-10 w-10 h-10 flex items-center justify-center rounded-full bg-black/50 text-white hover:bg-black/70 transition-colors cursor-pointer"
+            className="absolute top-4 right-4 z-10 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full bg-black/50 text-white transition-colors hover:bg-black/70"
             aria-label="Close preview"
           >
             <span className="material-symbols-outlined">close</span>

--- a/src/pages/components/workspace/shared/ReceiptNameField.tsx
+++ b/src/pages/components/workspace/shared/ReceiptNameField.tsx
@@ -18,7 +18,7 @@ export function ReceiptNameField({ name, onRename, className, iconClassName }: P
   };
 
   return (
-    <span className="inline-flex items-center gap-1 w-fit max-w-full">
+    <span className="inline-flex w-fit max-w-full items-center gap-1">
       <span
         ref={ref}
         contentEditable
@@ -35,7 +35,7 @@ export function ReceiptNameField({ name, onRename, className, iconClassName }: P
           }
         }}
         className={cn(
-          'font-bold text-sm text-on-surface bg-transparent outline-none cursor-text whitespace-nowrap rounded px-1 -mx-1 border border-transparent hover:border-outline-variant focus:border-primary transition-colors',
+          '-mx-1 cursor-text rounded border border-transparent bg-transparent px-1 text-sm font-bold whitespace-nowrap text-on-surface transition-colors outline-none hover:border-outline-variant focus:border-primary',
           className,
         )}
       >
@@ -43,7 +43,7 @@ export function ReceiptNameField({ name, onRename, className, iconClassName }: P
       </span>
       <span
         className={cn(
-          'material-symbols-outlined !text-xs flex-shrink-0 opacity-60',
+          'material-symbols-outlined flex-shrink-0 !text-xs opacity-60',
           iconClassName ?? 'text-on-surface-variant',
         )}
       >

--- a/src/pages/components/workspace/shared/ReceiptTabs.tsx
+++ b/src/pages/components/workspace/shared/ReceiptTabs.tsx
@@ -49,9 +49,9 @@ export function ReceiptTabs({
   };
 
   return (
-    <div className="flex items-center gap-3 mb-8">
+    <div className="mb-8 flex items-center gap-3">
       {/* Segmented pill */}
-      <div className="flex items-center bg-surface-container-low rounded-xl p-1 gap-0.5 overflow-x-auto">
+      <div className="flex items-center gap-0.5 overflow-x-auto rounded-xl bg-surface-container-low p-1">
         {receipts.map((receipt) => {
           const isActive = receipt.id === activeReceiptId;
           return (
@@ -60,9 +60,9 @@ export function ReceiptTabs({
               onClick={() => onSelect(receipt.id)}
               onDoubleClick={() => handleDoubleClick(receipt.id, receipt.name)}
               className={cn(
-                'group relative flex items-center gap-1.5 px-4 py-1.5 rounded-lg cursor-pointer select-none transition-all',
+                'group relative flex cursor-pointer items-center gap-1.5 rounded-lg px-4 py-1.5 transition-all select-none',
                 isActive
-                  ? 'bg-white shadow-sm text-on-surface'
+                  ? 'bg-white text-on-surface shadow-sm'
                   : 'text-on-surface-variant hover:text-on-surface',
               )}
             >
@@ -77,7 +77,7 @@ export function ReceiptTabs({
                     if (e.key === 'Escape') setEditingTabId(null);
                   }}
                   onClick={(e) => e.stopPropagation()}
-                  className="bg-transparent outline-none w-24 font-bold text-sm"
+                  className="w-24 bg-transparent text-sm font-bold outline-none"
                   autoFocus
                 />
               ) : (
@@ -98,7 +98,7 @@ export function ReceiptTabs({
                         handleDoubleClick(receipt.id, receipt.name);
                       }}
                       aria-label="Rename receipt"
-                      className="flex-shrink-0 flex items-center opacity-40 hover:opacity-100 transition-opacity"
+                      className="flex flex-shrink-0 items-center opacity-40 transition-opacity hover:opacity-100"
                     >
                       <span className="material-symbols-outlined !text-sm leading-none">edit</span>
                     </button>
@@ -113,9 +113,9 @@ export function ReceiptTabs({
                     onRemove(receipt.id);
                   }}
                   aria-label={`Remove ${receipt.name}`}
-                  className="flex-shrink-0 h-3.5 w-3.5 flex opacity-40 hover:opacity-100 transition-opacity"
+                  className="flex h-3.5 w-3.5 flex-shrink-0 opacity-40 transition-opacity hover:opacity-100"
                 >
-                  <span className="material-symbols-outlined leading-none !text-base cursor-pointer">
+                  <span className="material-symbols-outlined cursor-pointer !text-base leading-none">
                     close
                   </span>
                 </button>
@@ -128,10 +128,10 @@ export function ReceiptTabs({
           <div
             onClick={appendTab.onClick}
             className={cn(
-              'flex items-center gap-2 px-4 py-1.5 rounded-lg cursor-pointer select-none transition-all',
+              'flex cursor-pointer items-center gap-2 rounded-lg px-4 py-1.5 transition-all select-none',
               appendTab.isActive
-                ? 'bg-white shadow-sm text-on-surface font-bold'
-                : 'text-on-surface-variant hover:text-on-surface font-semibold',
+                ? 'bg-white font-bold text-on-surface shadow-sm'
+                : 'font-semibold text-on-surface-variant hover:text-on-surface',
             )}
           >
             <span className="material-symbols-outlined text-sm">{appendTab.icon}</span>
@@ -145,10 +145,10 @@ export function ReceiptTabs({
         <button
           type="button"
           onClick={onAdd}
-          className="flex items-center gap-1.5 px-3 py-2 rounded-xl text-on-surface-variant hover:text-primary hover:bg-surface-container-low transition-all whitespace-nowrap"
+          className="flex items-center gap-1.5 rounded-xl px-3 py-2 whitespace-nowrap text-on-surface-variant transition-all hover:bg-surface-container-low hover:text-primary"
         >
           <span className="material-symbols-outlined text-sm">add</span>
-          <span className="font-semibold text-sm">Add</span>
+          <span className="text-sm font-semibold">Add</span>
         </button>
       )}
     </div>

--- a/src/pages/components/workspace/shared/ReconciliationNotice.tsx
+++ b/src/pages/components/workspace/shared/ReconciliationNotice.tsx
@@ -13,8 +13,8 @@ export function ReconciliationNotice({ reconciliationCents, onApplyDiscount }: P
 
   if (isMatch) {
     return (
-      <div className="bg-secondary-container/20 p-4 rounded-2xl flex items-center gap-4 border border-secondary-container/30">
-        <div className="bg-secondary text-on-secondary rounded-full p-1 flex items-center justify-center flex-shrink-0">
+      <div className="flex items-center gap-4 rounded-2xl border border-secondary-container/30 bg-secondary-container/20 p-4">
+        <div className="flex flex-shrink-0 items-center justify-center rounded-full bg-secondary p-1 text-on-secondary">
           <span
             className="material-symbols-outlined text-sm"
             style={{ fontVariationSettings: "'FILL' 1" }}
@@ -23,10 +23,10 @@ export function ReconciliationNotice({ reconciliationCents, onApplyDiscount }: P
           </span>
         </div>
         <div>
-          <p className="text-xs font-extrabold text-on-secondary-container leading-tight">
+          <p className="text-xs leading-tight font-extrabold text-on-secondary-container">
             Totals match!
           </p>
-          <p className="text-[10px] text-on-secondary-container/80 mt-0.5">
+          <p className="mt-0.5 text-[10px] text-on-secondary-container/80">
             Verified against computed items.
           </p>
         </div>
@@ -35,9 +35,9 @@ export function ReconciliationNotice({ reconciliationCents, onApplyDiscount }: P
   }
 
   return (
-    <div className="bg-error-container/20 p-4 rounded-2xl flex flex-col gap-3 border border-error-container/30">
+    <div className="flex flex-col gap-3 rounded-2xl border border-error-container/30 bg-error-container/20 p-4">
       <div className="flex items-center gap-4">
-        <div className="bg-error text-on-error rounded-full p-1 flex items-center justify-center flex-shrink-0">
+        <div className="flex flex-shrink-0 items-center justify-center rounded-full bg-error p-1 text-on-error">
           <span
             className="material-symbols-outlined text-sm"
             style={{ fontVariationSettings: "'FILL' 1" }}
@@ -46,10 +46,10 @@ export function ReconciliationNotice({ reconciliationCents, onApplyDiscount }: P
           </span>
         </div>
         <div>
-          <p className="text-xs font-extrabold text-on-error-container leading-tight">
+          <p className="text-xs leading-tight font-extrabold text-on-error-container">
             Mismatch found ({formatCurrencyFromCents(Math.abs(reconciliationCents))})
           </p>
-          <p className="text-[10px] text-on-error-container/80 mt-0.5">
+          <p className="mt-0.5 text-[10px] text-on-error-container/80">
             {isOver
               ? 'Computed total is lower than receipt.'
               : 'Computed total is higher than receipt.'}
@@ -61,7 +61,7 @@ export function ReconciliationNotice({ reconciliationCents, onApplyDiscount }: P
           type="button"
           data-testid="apply-discount-reconcile-btn"
           onClick={onApplyDiscount}
-          className="w-full py-2 bg-on-error-container text-on-primary text-[10px] font-bold rounded-lg hover:opacity-90 transition-opacity uppercase tracking-wide"
+          className="w-full rounded-lg bg-on-error-container py-2 text-[10px] font-bold tracking-wide text-on-primary uppercase transition-opacity hover:opacity-90"
         >
           Resolve Difference (Apply Discount)
         </button>

--- a/src/pages/components/workspace/shared/SummaryTotals.tsx
+++ b/src/pages/components/workspace/shared/SummaryTotals.tsx
@@ -14,16 +14,16 @@ export function SummaryTotals({ split, discount, serviceCharge, gst, currency }:
   const activeChargesCents = split.serviceChargeCents + split.gstCents - split.discountCents;
 
   return (
-    <div className="space-y-4 pt-6 border-t border-surface-container-high mb-8">
-      <div className="flex justify-between items-center text-sm">
-        <span className="text-on-surface-variant font-medium">Subtotal</span>
+    <div className="mb-8 space-y-4 border-t border-surface-container-high pt-6">
+      <div className="flex items-center justify-between text-sm">
+        <span className="font-medium text-on-surface-variant">Subtotal</span>
         <span className="font-bold text-on-surface">
           {formatCurrencyFromCents(split.subtotalCents, currency)}
         </span>
       </div>
       {split.discountCents > 0 && (
-        <div className="flex justify-between items-center text-sm">
-          <span className="text-on-surface-variant font-medium">
+        <div className="flex items-center justify-between text-sm">
+          <span className="font-medium text-on-surface-variant">
             {buildChargeLabel('Discount', discount)}
           </span>
           <span className="font-bold text-secondary">
@@ -32,8 +32,8 @@ export function SummaryTotals({ split, discount, serviceCharge, gst, currency }:
         </div>
       )}
       {(split.serviceChargeCents > 0 || serviceCharge.enabled) && (
-        <div className="flex justify-between items-center text-sm">
-          <span className="text-on-surface-variant font-medium">
+        <div className="flex items-center justify-between text-sm">
+          <span className="font-medium text-on-surface-variant">
             {buildChargeLabel('Service Charge', serviceCharge)}
           </span>
           <span className="font-bold text-primary">
@@ -42,8 +42,8 @@ export function SummaryTotals({ split, discount, serviceCharge, gst, currency }:
         </div>
       )}
       {(split.gstCents > 0 || gst.enabled) && (
-        <div className="flex justify-between items-center text-sm">
-          <span className="text-on-surface-variant font-medium">
+        <div className="flex items-center justify-between text-sm">
+          <span className="font-medium text-on-surface-variant">
             {buildChargeLabel('GST / Tax', gst)}
           </span>
           <span className="font-bold text-primary">
@@ -52,17 +52,17 @@ export function SummaryTotals({ split, discount, serviceCharge, gst, currency }:
         </div>
       )}
       {activeChargesCents !== 0 && (
-        <div className="flex justify-between items-center text-sm">
-          <span className="text-on-surface-variant font-medium">Active Charges</span>
+        <div className="flex items-center justify-between text-sm">
+          <span className="font-medium text-on-surface-variant">Active Charges</span>
           <span className="font-bold text-primary">
             {activeChargesCents > 0 ? '+' : ''}
             {formatCurrencyFromCents(activeChargesCents, currency)}
           </span>
         </div>
       )}
-      <div className="flex justify-between items-center pt-2">
+      <div className="flex items-center justify-between pt-2">
         <span className="text-base font-extrabold text-primary">Computed Total</span>
-        <span className="text-2xl font-extrabold text-primary font-headline">
+        <span className="font-headline text-2xl font-extrabold text-primary">
           {formatCurrencyFromCents(split.grandTotalCents, currency)}
         </span>
       </div>

--- a/src/pages/components/workspace/steps/AssignStep.tsx
+++ b/src/pages/components/workspace/steps/AssignStep.tsx
@@ -49,20 +49,20 @@ export function AssignStep({
     <div>
       {/* Header — desktop */}
       <div className="mb-6 hidden md:block">
-        <h1 className="text-4xl md:text-5xl font-extrabold font-headline text-on-surface tracking-tight mb-2">
+        <h1 className="font-headline mb-2 text-4xl font-extrabold tracking-tight text-on-surface md:text-5xl">
           Assign Items
         </h1>
-        <p className="text-on-surface-variant text-lg">
+        <p className="text-lg text-on-surface-variant">
           Assign each item to the people who ordered it.
         </p>
       </div>
 
       {/* Header — mobile */}
       <div className="mb-4 md:hidden">
-        <h1 className="text-xl font-extrabold font-headline text-on-surface tracking-tight">
+        <h1 className="font-headline text-xl font-extrabold tracking-tight text-on-surface">
           Assign Items
         </h1>
-        <p className="text-on-surface-variant text-xs mt-0.5">
+        <p className="mt-0.5 text-xs text-on-surface-variant">
           Assign each item to the people who ordered it.
         </p>
       </div>
@@ -84,7 +84,7 @@ export function AssignStep({
       />
 
       {itemsSubPhase === 'assign' && activeReceipt && (
-        <div className="flex items-center gap-2 mt-3 mb-1 px-1">
+        <div className="mt-3 mb-1 flex items-center gap-2 px-1">
           <span className="material-symbols-outlined text-sm text-outline">receipt_long</span>
           <ReceiptNameField
             key={activeReceiptId}
@@ -160,7 +160,7 @@ function AssignPhase({
 
   if (!activeItem) {
     return (
-      <p className="text-sm text-on-surface-variant text-center py-12">No items available yet.</p>
+      <p className="py-12 text-center text-sm text-on-surface-variant">No items available yet.</p>
     );
   }
 
@@ -171,12 +171,12 @@ function AssignPhase({
       {/* Counter + nav arrows */}
       <div className="flex items-center justify-between">
         <div>
-          <p className="text-xs font-bold uppercase tracking-widest text-on-surface-variant">
+          <p className="text-xs font-bold tracking-widest text-on-surface-variant uppercase">
             Assigning Items
           </p>
           <p
             data-testid="assign-item-counter"
-            className="text-2xl font-extrabold text-on-surface font-headline"
+            className="font-headline text-2xl font-extrabold text-on-surface"
           >
             Item {activeItemIndex + 1} of {items.length}
           </p>
@@ -187,7 +187,7 @@ function AssignPhase({
             data-testid="assign-prev-item-btn"
             onClick={() => onActiveItemIndexChange(Math.max(0, activeItemIndex - 1))}
             disabled={activeItemIndex === 0}
-            className="w-10 h-10 rounded-full bg-surface-container flex items-center justify-center hover:bg-surface-container-high transition-colors disabled:opacity-30"
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-surface-container transition-colors hover:bg-surface-container-high disabled:opacity-30"
           >
             <span className="material-symbols-outlined text-on-surface">chevron_left</span>
           </button>
@@ -196,7 +196,7 @@ function AssignPhase({
             data-testid="assign-next-item-btn"
             onClick={() => onActiveItemIndexChange(Math.min(items.length - 1, activeItemIndex + 1))}
             disabled={activeItemIndex >= items.length - 1}
-            className="w-10 h-10 rounded-full bg-surface-container flex items-center justify-center hover:bg-surface-container-high transition-colors disabled:opacity-30"
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-surface-container transition-colors hover:bg-surface-container-high disabled:opacity-30"
           >
             <span className="material-symbols-outlined text-on-surface">chevron_right</span>
           </button>
@@ -204,16 +204,16 @@ function AssignPhase({
       </div>
 
       {/* Item card */}
-      <div className="bg-surface-container-lowest rounded-2xl p-5 shadow-[0_8px_24px_rgba(25,28,29,0.06)]">
-        <div className="flex justify-between items-start mb-1">
-          <h2 className="text-2xl md:text-3xl font-bold font-headline text-on-surface">
+      <div className="rounded-2xl bg-surface-container-lowest p-5 shadow-[0_8px_24px_rgba(25,28,29,0.06)]">
+        <div className="mb-1 flex items-start justify-between">
+          <h2 className="font-headline text-2xl font-bold text-on-surface md:text-3xl">
             {activeItem.name || 'Untitled item'}
           </h2>
           {isAssigned ? (
             <div
               data-testid="assign-item-status"
               data-assigned="true"
-              className="flex items-center gap-1.5 text-secondary font-bold text-sm flex-shrink-0 ml-3"
+              className="ml-3 flex flex-shrink-0 items-center gap-1.5 text-sm font-bold text-secondary"
             >
               <span
                 className="material-symbols-outlined text-sm"
@@ -227,7 +227,7 @@ function AssignPhase({
             <div
               data-testid="assign-item-status"
               data-assigned="false"
-              className="flex items-center gap-1.5 text-error font-bold text-sm flex-shrink-0 ml-3"
+              className="ml-3 flex flex-shrink-0 items-center gap-1.5 text-sm font-bold text-error"
             >
               <span
                 className="material-symbols-outlined text-sm"
@@ -239,13 +239,13 @@ function AssignPhase({
             </div>
           )}
         </div>
-        <div className="text-3xl md:text-4xl font-extrabold font-headline text-primary">
+        <div className="font-headline text-3xl font-extrabold text-primary md:text-4xl">
           {priceCents !== null ? formatCurrencyFromCents(priceCents, currency) : '—'}
         </div>
       </div>
 
       {/* Who's sharing header */}
-      <div className="flex justify-between items-center">
+      <div className="flex items-center justify-between">
         <span className="text-base font-semibold text-on-surface">Who's sharing?</span>
         <div className="flex gap-3">
           <button
@@ -253,7 +253,7 @@ function AssignPhase({
             data-testid="assign-select-all-btn"
             onClick={handleSelectAll}
             disabled={people.length === 0}
-            className="text-primary font-bold text-sm hover:opacity-70 transition-opacity disabled:opacity-40"
+            className="text-sm font-bold text-primary transition-opacity hover:opacity-70 disabled:opacity-40"
           >
             Select all
           </button>
@@ -262,7 +262,7 @@ function AssignPhase({
             data-testid="assign-select-none-btn"
             onClick={handleSelectNone}
             disabled={people.length === 0}
-            className="text-on-surface-variant font-semibold text-sm hover:opacity-70 transition-opacity disabled:opacity-40"
+            className="text-sm font-semibold text-on-surface-variant transition-opacity hover:opacity-70 disabled:opacity-40"
           >
             None
           </button>
@@ -270,7 +270,7 @@ function AssignPhase({
       </div>
 
       {/* Person toggle buttons */}
-      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
         {people.map((person, index) => {
           const isSelected = activeItem.assignment.personIds.includes(person.id);
           const assignedCount = activeItem.assignment.personIds.length;
@@ -292,15 +292,15 @@ function AssignPhase({
                 }));
               }}
               className={cn(
-                'flex items-center gap-3 px-4 py-3 rounded-xl transition-all text-left',
+                'flex items-center gap-3 rounded-xl px-4 py-3 text-left transition-all',
                 isSelected
-                  ? 'bg-surface-container-lowest border-2 border-secondary shadow-[0_4px_14px_rgba(27,109,36,0.2)]'
-                  : 'bg-surface-container-low border-2 border-transparent hover:bg-surface-container',
+                  ? 'border-2 border-secondary bg-surface-container-lowest shadow-[0_4px_14px_rgba(27,109,36,0.2)]'
+                  : 'border-2 border-transparent bg-surface-container-low hover:bg-surface-container',
               )}
             >
               <PersonAvatar name={person.name} colorIndex={index} />
-              <div className="flex-1 min-w-0">
-                <span className="block font-bold text-on-surface text-sm">{person.name}</span>
+              <div className="min-w-0 flex-1">
+                <span className="block text-sm font-bold text-on-surface">{person.name}</span>
                 <span
                   className={cn(
                     'text-sm font-semibold',
@@ -311,9 +311,9 @@ function AssignPhase({
                 </span>
               </div>
               {isSelected && (
-                <div className="flex-shrink-0 w-5 h-5 rounded-full bg-secondary flex items-center justify-center">
+                <div className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-secondary">
                   <span
-                    className="material-symbols-outlined !text-xs text-on-secondary leading-none"
+                    className="material-symbols-outlined !text-xs leading-none text-on-secondary"
                     style={{ fontVariationSettings: "'FILL' 1" }}
                   >
                     check
@@ -326,7 +326,7 @@ function AssignPhase({
       </div>
 
       {/* Double-tap hint */}
-      <div className="flex items-center gap-1.5 text-on-surface-variant text-xs italic">
+      <div className="flex items-center gap-1.5 text-xs text-on-surface-variant italic">
         <span className="material-symbols-outlined text-sm">info</span>
         Double-tap a person to assign only them.
       </div>
@@ -345,8 +345,8 @@ type ReviewPhaseProps = {
 function ReviewPhase({ items, people, onEditItem }: ReviewPhaseProps) {
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-2xl font-bold font-headline text-on-surface">Review Assignments</h2>
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="font-headline text-2xl font-bold text-on-surface">Review Assignments</h2>
         <span className="text-sm text-on-surface-variant">
           {items.length} item{items.length !== 1 ? 's' : ''}
         </span>
@@ -366,16 +366,16 @@ function ReviewPhase({ items, people, onEditItem }: ReviewPhaseProps) {
               className={cn(
                 'flex items-center justify-between gap-3 rounded-xl border p-4 transition-all',
                 isAssigned
-                  ? 'bg-surface-container-lowest border-surface-container-highest hover:border-outline-variant/30'
-                  : 'bg-surface-container-lowest border-error/50 hover:border-error',
+                  ? 'border-surface-container-highest bg-surface-container-lowest hover:border-outline-variant/30'
+                  : 'border-error/50 bg-surface-container-lowest hover:border-error',
               )}
             >
-              <div className="space-y-1 flex-1 min-w-0">
-                <p className="font-bold text-on-surface truncate">
+              <div className="min-w-0 flex-1 space-y-1">
+                <p className="truncate font-bold text-on-surface">
                   {item.name || `Item ${index + 1}`}
                 </p>
                 {priceCents !== null && (
-                  <span className="block text-sm font-bold text-primary font-headline">
+                  <span className="font-headline block text-sm font-bold text-primary">
                     {formatCurrencyFromCents(priceCents)}
                   </span>
                 )}
@@ -392,7 +392,7 @@ function ReviewPhase({ items, people, onEditItem }: ReviewPhaseProps) {
                 type="button"
                 data-testid="wizard-edit-btn"
                 onClick={() => onEditItem(index)}
-                className="shrink-0 flex items-center gap-1 border border-outline-variant text-primary rounded-xl px-3 py-2 text-sm font-semibold hover:border-primary hover:bg-primary/5 transition-all"
+                className="flex shrink-0 items-center gap-1 rounded-xl border border-outline-variant px-3 py-2 text-sm font-semibold text-primary transition-all hover:border-primary hover:bg-primary/5"
               >
                 <span className="material-symbols-outlined text-sm">edit</span>
                 Edit

--- a/src/pages/components/workspace/steps/CurrencyToggle.tsx
+++ b/src/pages/components/workspace/steps/CurrencyToggle.tsx
@@ -11,12 +11,12 @@ interface Props {
 
 export function CurrencyToggle({ showBaseCurrency, onToggle, activeTab, currentCurrency }: Props) {
   return (
-    <div className="flex items-center gap-1 bg-surface-container rounded-full p-0.5 text-xs font-semibold">
+    <div className="flex items-center gap-1 rounded-full bg-surface-container p-0.5 text-xs font-semibold">
       <button
         type="button"
         onClick={() => onToggle(false)}
         className={cn(
-          'px-3 py-1 rounded-full transition-all',
+          'rounded-full px-3 py-1 transition-all',
           !showBaseCurrency
             ? 'bg-primary text-on-primary shadow-sm'
             : 'text-on-surface-variant hover:text-on-surface',
@@ -30,7 +30,7 @@ export function CurrencyToggle({ showBaseCurrency, onToggle, activeTab, currentC
         type="button"
         onClick={() => onToggle(true)}
         className={cn(
-          'px-3 py-1 rounded-full transition-all',
+          'rounded-full px-3 py-1 transition-all',
           showBaseCurrency
             ? 'bg-primary text-on-primary shadow-sm'
             : 'text-on-surface-variant hover:text-on-surface',

--- a/src/pages/components/workspace/steps/CurrencyToggle.tsx
+++ b/src/pages/components/workspace/steps/CurrencyToggle.tsx
@@ -23,7 +23,7 @@ export function CurrencyToggle({ showBaseCurrency, onToggle, activeTab, currentC
         )}
       >
         {activeTab === 'total'
-          ? 'Original'
+          ? 'As billed'
           : `${getCurrencySymbol(currentCurrency)} ${currentCurrency}`}
       </button>
       <button

--- a/src/pages/components/workspace/steps/ExportActions.tsx
+++ b/src/pages/components/workspace/steps/ExportActions.tsx
@@ -24,7 +24,7 @@ export function ExportActions({
         data-testid="export-save-image-btn"
         onClick={onDownload}
         disabled={busy !== null}
-        className="flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-surface-container-highest text-primary font-bold text-sm hover:bg-primary hover:text-on-primary transition-all disabled:opacity-60"
+        className="flex items-center justify-center gap-2 rounded-xl bg-surface-container-highest px-6 py-3 text-sm font-bold text-primary transition-all hover:bg-primary hover:text-on-primary disabled:opacity-60"
       >
         <span className="material-symbols-outlined text-base">image</span>
         {busy === 'downloading' ? 'Generating…' : 'Save Image'}
@@ -34,7 +34,7 @@ export function ExportActions({
         data-testid="export-copy-text-btn"
         onClick={onShare}
         disabled={busy !== null}
-        className="flex items-center justify-center gap-2 px-6 py-3 rounded-xl border border-outline-variant/30 text-primary font-bold text-sm hover:border-primary transition-all disabled:opacity-60"
+        className="flex items-center justify-center gap-2 rounded-xl border border-outline-variant/30 px-6 py-3 text-sm font-bold text-primary transition-all hover:border-primary disabled:opacity-60"
       >
         <span className="material-symbols-outlined text-base">
           {copied ? 'check' : nativeShareSupported ? 'share' : 'content_copy'}

--- a/src/pages/components/workspace/steps/GrandTotalCard.tsx
+++ b/src/pages/components/workspace/steps/GrandTotalCard.tsx
@@ -40,8 +40,8 @@ export function GrandTotalCard({
       className="rounded-2xl p-6 text-left shadow-md"
       style={{ background: 'linear-gradient(135deg, #2d6a7f 0%, #1e5068 100%)' }}
     >
-      <div className="flex items-start justify-between mb-4">
-        <span className="text-sm font-bold uppercase tracking-widest text-white flex-1 min-w-0 mr-2">
+      <div className="mb-4 flex items-start justify-between">
+        <span className="mr-2 min-w-0 flex-1 text-sm font-bold tracking-widest text-white uppercase">
           {currentReceipt ? (
             <ReceiptNameField
               key={currentReceipt.id}
@@ -54,17 +54,17 @@ export function GrandTotalCard({
             'Grand Total'
           )}
         </span>
-        <div className="w-7 h-7 rounded-lg bg-white/10 flex items-center justify-center">
-          <span className="material-symbols-outlined text-white/50 text-sm">
+        <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-white/10">
+          <span className="material-symbols-outlined text-sm text-white/50">
             account_balance_wallet
           </span>
         </div>
       </div>
-      <div className="flex items-baseline gap-1 mb-5">
+      <div className="mb-5 flex items-baseline gap-1">
         <span className="text-xl font-semibold text-white/60">
           {getCurrencySymbol(displayCurrency)}
         </span>
-        <span className="text-4xl font-semibold text-white font-headline leading-none">
+        <span className="font-headline text-4xl leading-none font-semibold text-white">
           {(grandTotal / 100).toFixed(2)}
         </span>
       </div>
@@ -72,7 +72,7 @@ export function GrandTotalCard({
       <div className="mb-4">
         <label
           htmlFor="payer-mobile"
-          className="block text-xs font-semibold text-white/60 uppercase tracking-widest mb-1.5"
+          className="mb-1.5 block text-xs font-semibold tracking-widest text-white/60 uppercase"
         >
           PayNow Number
         </label>
@@ -83,18 +83,18 @@ export function GrandTotalCard({
           onChange={(e) => handlePayerMobileChange(e.target.value)}
           onBlur={handlePayerMobileBlur}
           placeholder="9123 4567"
-          className="w-full bg-white/10 text-white placeholder:text-white/30 rounded-xl px-3 py-2 text-sm font-medium outline-none focus:ring-2 focus:ring-white/30"
+          className="w-full rounded-xl bg-white/10 px-3 py-2 text-sm font-medium text-white outline-none placeholder:text-white/30 focus:ring-2 focus:ring-white/30"
         />
         {mobileError ? (
-          <p className="text-xs text-red-300 mt-1">{mobileError}</p>
+          <p className="mt-1 text-xs text-red-300">{mobileError}</p>
         ) : (
-          <p className="text-xs text-white/50 mt-1.5">
+          <p className="mt-1.5 text-xs text-white/50">
             Generates a PayNow QR per person so everyone can pay the bill payer back.
           </p>
         )}
       </div>
 
-      <div className="border-t border-white/10 pt-4 flex items-center gap-2.5">
+      <div className="flex items-center gap-2.5 border-t border-white/10 pt-4">
         <span
           className="material-symbols-outlined !text-sm text-cyan-300"
           style={{ fontVariationSettings: "'FILL' 1" }}

--- a/src/pages/components/workspace/steps/PeopleStep.tsx
+++ b/src/pages/components/workspace/steps/PeopleStep.tsx
@@ -21,24 +21,24 @@ export function PeopleStep({
     <div className="space-y-5">
       {/* Header — desktop */}
       <div className="mb-6 hidden md:block">
-        <h1 className="text-4xl md:text-5xl font-extrabold font-headline text-on-surface tracking-tight mb-2">
+        <h1 className="font-headline mb-2 text-4xl font-extrabold tracking-tight text-on-surface md:text-5xl">
           Who's Splitting?
         </h1>
-        <p className="text-on-surface-variant text-lg">Add everyone who's part of this bill.</p>
+        <p className="text-lg text-on-surface-variant">Add everyone who's part of this bill.</p>
       </div>
 
       {/* Header — mobile */}
       <div className="mb-2 md:hidden">
-        <h1 className="text-xl font-extrabold font-headline text-on-surface tracking-tight">
+        <h1 className="font-headline text-xl font-extrabold tracking-tight text-on-surface">
           Who's Splitting?
         </h1>
-        <p className="text-on-surface-variant text-xs mt-0.5">
+        <p className="mt-0.5 text-xs text-on-surface-variant">
           Add everyone who's part of this bill.
         </p>
       </div>
 
       {/* Input card */}
-      <div className="bg-surface-container-lowest rounded-2xl p-5 shadow-[0_8px_24px_rgba(25,28,29,0.06)]">
+      <div className="rounded-2xl bg-surface-container-lowest p-5 shadow-[0_8px_24px_rgba(25,28,29,0.06)]">
         <form onSubmit={onPeopleSubmit} className="flex gap-3">
           <input
             id="new-people-input"
@@ -46,18 +46,18 @@ export function PeopleStep({
             value={peopleInput}
             onChange={(e) => onPeopleInputChange(e.target.value)}
             placeholder="Names, e.g. Alice, Bob"
-            className="flex-1 px-4 py-3 bg-surface-container rounded-xl border-none focus:ring-0 text-on-surface placeholder:text-outline outline-none text-base"
+            className="flex-1 rounded-xl border-none bg-surface-container px-4 py-3 text-base text-on-surface outline-none placeholder:text-outline focus:ring-0"
           />
           <button
             type="submit"
             data-testid="people-add-btn"
-            className="px-4 py-3 bg-gradient-to-br from-primary to-primary-container text-on-primary font-bold rounded-xl active:scale-95 transition-transform flex items-center gap-2"
+            className="flex items-center gap-2 rounded-xl bg-gradient-to-br from-primary to-primary-container px-4 py-3 font-bold text-on-primary transition-transform active:scale-95"
           >
             <span className="material-symbols-outlined">add</span>
             <span className="hidden sm:inline">Add</span>
           </button>
         </form>
-        <p className="mt-2 text-[10px] text-on-surface-variant/70 font-medium px-1">
+        <p className="mt-2 px-1 text-[10px] font-medium text-on-surface-variant/70">
           Tip: Input multiple names with commas
         </p>
       </div>
@@ -66,7 +66,7 @@ export function PeopleStep({
       {people.length === 0 ? (
         <div
           data-testid="people-empty-state"
-          className="flex flex-col items-center justify-center py-14 border-2 border-dashed border-outline-variant/30 rounded-2xl text-center gap-3"
+          className="flex flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed border-outline-variant/30 py-14 text-center"
         >
           <span className="material-symbols-outlined text-3xl text-outline">group</span>
           <p className="text-sm font-semibold text-on-surface-variant">No one added yet.</p>
@@ -83,14 +83,14 @@ export function PeopleStep({
                 data-testid={`person-chip-${person.id}`}
                 onClick={() => onRemovePerson(person.id)}
                 className={cn(
-                  'flex items-center gap-2 px-3 py-1.5 rounded-full border text-sm font-semibold transition hover:opacity-75 active:scale-95',
+                  'flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-semibold transition hover:opacity-75 active:scale-95',
                   color.lightBg,
                   color.border,
                   color.accent,
                 )}
               >
                 <span
-                  className="w-2 h-2 rounded-full flex-shrink-0"
+                  className="h-2 w-2 flex-shrink-0 rounded-full"
                   style={{ backgroundColor: color.avatarBg }}
                 />
                 {person.name}
@@ -104,7 +104,7 @@ export function PeopleStep({
       {/* Status */}
       {people.length > 0 && (
         <div className="flex items-center gap-2 text-sm font-medium text-on-surface-variant">
-          <span className="w-2 h-2 rounded-full bg-secondary flex-shrink-0" />
+          <span className="h-2 w-2 flex-shrink-0 rounded-full bg-secondary" />
           {people.length} {people.length === 1 ? 'person' : 'people'} added
         </div>
       )}

--- a/src/pages/components/workspace/steps/ReceiptStep.tsx
+++ b/src/pages/components/workspace/steps/ReceiptStep.tsx
@@ -70,20 +70,20 @@ export function ReceiptStep({
     <div>
       {/* Step header — desktop */}
       <div className="mb-6 hidden md:block">
-        <h1 className="text-4xl md:text-5xl font-extrabold font-headline tracking-tight text-on-surface mb-2">
+        <h1 className="font-headline mb-2 text-4xl font-extrabold tracking-tight text-on-surface md:text-5xl">
           Add Receipts
         </h1>
-        <p className="text-on-surface-variant text-lg">
+        <p className="text-lg text-on-surface-variant">
           Verify scanned items and add missing charges.
         </p>
       </div>
 
       {/* Step header — mobile */}
       <div className="mb-4 md:hidden">
-        <h1 className="text-xl font-extrabold font-headline text-on-surface tracking-tight">
+        <h1 className="font-headline text-xl font-extrabold tracking-tight text-on-surface">
           Add Receipts
         </h1>
-        <p className="text-on-surface-variant text-xs mt-0.5">
+        <p className="mt-0.5 text-xs text-on-surface-variant">
           Verify scanned items and add missing charges.
         </p>
       </div>
@@ -112,16 +112,16 @@ export function ReceiptStep({
       </div>
 
       {/* Layout: left 8 cols + right 4 cols */}
-      <div className="grid grid-cols-1 lg:grid-cols-12 gap-10">
+      <div className="grid grid-cols-1 gap-10 lg:grid-cols-12">
         {/* Left: Image placeholder + items */}
-        <div className="lg:col-span-8 space-y-6">
+        <div className="space-y-6 lg:col-span-8">
           {/* Compact image placeholder */}
-          <div className="flex items-center gap-4 bg-surface-container-lowest rounded-2xl px-5 py-4">
-            <div className="w-12 h-12 rounded-xl bg-surface-container flex items-center justify-center flex-shrink-0">
+          <div className="flex items-center gap-4 rounded-2xl bg-surface-container-lowest px-5 py-4">
+            <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-xl bg-surface-container">
               <span className="material-symbols-outlined text-2xl text-outline">receipt_long</span>
             </div>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 flex-wrap">
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
                 <ReceiptNameField
                   key={activeReceiptId}
                   name={activeReceipt?.name ?? ''}
@@ -152,7 +152,7 @@ export function ReceiptStep({
           {/* Line items */}
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <h3 className="text-sm font-bold uppercase tracking-widest text-on-surface-variant">
+              <h3 className="text-sm font-bold tracking-widest text-on-surface-variant uppercase">
                 Line Items
               </h3>
               {hasItems && (
@@ -180,16 +180,16 @@ export function ReceiptStep({
                   type="button"
                   data-testid="receipt-add-item-btn"
                   onClick={onAddItem}
-                  className="w-full flex items-center justify-center gap-2 p-4 border-2 border-dashed border-outline-variant rounded-2xl text-on-surface-variant hover:text-primary hover:bg-surface-container-low transition-all"
+                  className="flex w-full items-center justify-center gap-2 rounded-2xl border-2 border-dashed border-outline-variant p-4 text-on-surface-variant transition-all hover:bg-surface-container-low hover:text-primary"
                 >
                   <span className="material-symbols-outlined">add_circle</span>
-                  <span className="font-bold uppercase text-sm tracking-widest">Add New Item</span>
+                  <span className="text-sm font-bold tracking-widest uppercase">Add New Item</span>
                 </button>
               </div>
             ) : (
               <div
                 data-testid="receipt-empty-state"
-                className="flex flex-col items-center justify-center py-12 border-2 border-dashed border-outline-variant/30 rounded-2xl bg-surface-bright text-center gap-3"
+                className="flex flex-col items-center justify-center gap-3 rounded-2xl border-2 border-dashed border-outline-variant/30 bg-surface-bright py-12 text-center"
               >
                 <span className="material-symbols-outlined text-3xl text-outline">receipt</span>
                 <p className="text-sm font-semibold text-on-surface-variant">No items yet</p>
@@ -198,7 +198,7 @@ export function ReceiptStep({
                   type="button"
                   data-testid="receipt-add-item-btn"
                   onClick={onAddItem}
-                  className="mt-2 flex items-center gap-2 px-4 py-2 bg-gradient-to-br from-primary to-primary-container text-on-primary rounded-xl font-bold text-sm active:scale-95 transition-transform"
+                  className="mt-2 flex items-center gap-2 rounded-xl bg-gradient-to-br from-primary to-primary-container px-4 py-2 text-sm font-bold text-on-primary transition-transform active:scale-95"
                 >
                   <span className="material-symbols-outlined text-sm">add</span>
                   Add Item

--- a/src/pages/components/workspace/steps/SummaryStep.tsx
+++ b/src/pages/components/workspace/steps/SummaryStep.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import type { ChargeState, Person, Receipt, SplitResult } from '@shared/types';
 import { formatCurrencyFromCents } from '@shared/logic/core/money';
 import { generateReceiptSplitImageLight } from '@features/split-results/logic/receiptSplitImageLight';
@@ -11,17 +11,15 @@ import {
 } from '@features/split-results/logic/shareSplit';
 import { PersonCard } from '@pages/components/workspace/shared/PersonCard';
 import { BASE_CURRENCY } from '@shared/constants';
-import { convertSplitResult } from '@shared/logic/core/exchangeRates';
-import { useReceiptStore } from '@shared/stores/receiptStore';
-import { useCurrencyStore } from '@shared/stores/currencyStore';
 import { normalizeMobile } from '@shared/logic/core/paynow';
-import { generatePaynowQrDataUrls } from '@shared/logic/core/paynowQr';
+import { useReceiptStore } from '@shared/stores/receiptStore';
 import { SummaryTabs } from './SummaryTabs';
 import { CurrencyToggle } from './CurrencyToggle';
 import { GrandTotalCard } from './GrandTotalCard';
 import { ExportActions } from './ExportActions';
+import { useSummaryView } from './useSummaryView';
 
-type Props = {
+export type SummaryStepProps = {
   people: Person[];
   receipts: Receipt[];
   activeReceiptId: string;
@@ -52,7 +50,7 @@ export function SummaryStep({
   onApplyDiscount,
   onAddReceipt,
   onRenameReceipt,
-}: Props) {
+}: SummaryStepProps) {
   const isMultiReceipt = receipts.length > 1;
   const [activeTab, setActiveTab] = useState<string>(
     isMultiReceipt ? 'total' : (receipts[0]?.id ?? 'total'),
@@ -62,76 +60,29 @@ export function SummaryStep({
   const [showBaseCurrency, setShowBaseCurrency] = useState(false);
   const [copied, setCopied] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
-  const [qrDataUrls, setQrDataUrls] = useState<Record<string, string>>({});
   const copyTimeoutRef = useRef<number | null>(null);
 
   const payerMobile = useReceiptStore((s) => s.payerMobile);
-
-  const activeReceiptIndex = receipts.findIndex((r) => r.id === activeTab);
-  const currentSplit =
-    activeTab === 'total' ? consolidatedSplit : (splitByReceipt[activeReceiptIndex] ?? split);
-  const currentReceipt = activeTab === 'total' ? null : receipts[activeReceiptIndex];
-  const currentDiscount = currentReceipt?.discount ?? discount;
-  const currentServiceCharge = currentReceipt?.serviceCharge ?? serviceCharge;
-  const currentGst = currentReceipt?.gst ?? gst;
-
-  // Consolidated tab shows SGD; individual receipt tabs show the receipt's native currency
-  const currentCurrency =
-    activeTab === 'total' ? BASE_CURRENCY : (currentReceipt?.currency ?? BASE_CURRENCY);
-  const isForeignCurrency = currentCurrency !== BASE_CURRENCY;
-  const exchangeRates = useCurrencyStore((s) => s.exchangeRates);
-  const convertedSplit = isForeignCurrency
-    ? convertSplitResult(
-        currentSplit,
-        currentCurrency,
-        BASE_CURRENCY,
-        exchangeRates,
-        currentReceipt?.exchangeRateOverride ?? null,
-      )
-    : null;
-  const displaySplit = isForeignCurrency && showBaseCurrency ? convertedSplit! : currentSplit;
-  const displayCurrency = isForeignCurrency && showBaseCurrency ? BASE_CURRENCY : currentCurrency;
-
-  const hasAnyForeignReceipt = receipts.some(
-    (r) => (r.currency ?? BASE_CURRENCY) !== BASE_CURRENCY,
-  );
-  const convertedSplitByReceipt = splitByReceipt.map((s, i) => {
-    const currency = receipts[i]?.currency ?? BASE_CURRENCY;
-    return currency !== BASE_CURRENCY
-      ? convertSplitResult(
-          s,
-          currency,
-          BASE_CURRENCY,
-          exchangeRates,
-          receipts[i]?.exchangeRateOverride ?? null,
-        )
-      : s;
+  const { view, qrDataUrls } = useSummaryView({
+    people,
+    receipts,
+    split,
+    consolidatedSplit,
+    splitByReceipt,
+    discount,
+    serviceCharge,
+    gst,
+    activeTab,
+    showBaseCurrency,
   });
 
-  const grandTotal = Object.values(displaySplit.totalByPersonCents).reduce((s, v) => s + v, 0);
+  // Narrow per-tab fields to avoid repetitive view.kind checks in JSX
+  const receiptForExport = view.kind === 'receipt' ? view.receipt : null;
+  const nativeCurrency = view.kind === 'receipt' ? view.nativeCurrency : BASE_CURRENCY;
+  const showCurrencyControls =
+    (view.kind === 'receipt' && view.isForeign) || (view.kind === 'total' && view.hasAnyForeign);
 
   const nativeShareSupported = getShareSupport() === 'native';
-
-  // The split used for QR amounts is always in SGD regardless of display currency.
-  const sgdSplitForQr = isForeignCurrency ? (convertedSplit ?? currentSplit) : currentSplit;
-
-  // Stable key that changes whenever the per-person SGD amounts change (e.g. on tab switch).
-  const qrAmountsKey = people
-    .map((p) => `${p.id}:${sgdSplitForQr.totalByPersonCents[p.id] ?? 0}`)
-    .join(',');
-
-  useEffect(() => {
-    let cancelled = false;
-    generatePaynowQrDataUrls(people, sgdSplitForQr, payerMobile).then((urls) => {
-      if (!cancelled) setQrDataUrls(urls);
-    });
-    return () => {
-      cancelled = true;
-    };
-    // qrAmountsKey encodes every person's SGD amount, so it covers `people` and
-    // `sgdSplitForQr` transitively — no need to list them directly.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [payerMobile, qrAmountsKey]);
 
   const handleDownload = async () => {
     setBusy('downloading');
@@ -139,20 +90,20 @@ export function SummaryStep({
     try {
       const blob = await generateReceiptSplitImageLight({
         people,
-        split: displaySplit,
-        sgdSplit: sgdSplitForQr,
+        split: view.displaySplit,
+        sgdSplit: view.sgdSplit,
         receipts,
         splitByReceipt,
-        discount: currentDiscount,
-        serviceCharge: currentServiceCharge,
-        gst: currentGst,
-        receiptName: currentReceipt?.name,
+        discount: view.discount,
+        serviceCharge: view.serviceCharge,
+        gst: view.gst,
+        receiptName: receiptForExport?.name,
         reconciliationCents,
         includeItemDetails: showDetails,
-        currency: displayCurrency,
+        currency: view.displayCurrency,
         payerMobile: normalizeMobile(payerMobile) ?? undefined,
       });
-      downloadImage(blob, buildDownloadFilename('split', currentReceipt?.name));
+      downloadImage(blob, buildDownloadFilename('split', receiptForExport?.name));
     } catch {
       setExportError('Failed to generate image.');
     } finally {
@@ -164,9 +115,9 @@ export function SummaryStep({
     setBusy('copying');
     const text = buildSplitShareText({
       people,
-      receiptName: currentReceipt?.name ?? '',
-      split: displaySplit,
-      currency: displayCurrency,
+      receiptName: receiptForExport?.name ?? '',
+      split: view.displaySplit,
+      currency: view.displayCurrency,
     });
     try {
       await shareText(text);
@@ -189,21 +140,21 @@ export function SummaryStep({
       <div className="mb-8">
         {/* Desktop header */}
         <div className="mb-6 hidden md:block">
-          <h1 className="text-4xl md:text-5xl font-extrabold tracking-tight text-on-surface mb-2 font-headline">
+          <h1 className="font-headline mb-2 text-4xl font-extrabold tracking-tight text-on-surface md:text-5xl">
             Final Breakdown
           </h1>
-          <p className="text-on-surface-variant text-lg">
-            Review the consolidated total or individual receipt details.
+          <p className="text-lg text-on-surface-variant">
+            Review the consolidated grand total or individual receipt details.
           </p>
         </div>
 
         {/* Mobile header */}
         <div className="mb-4 md:hidden">
-          <h1 className="text-xl font-extrabold font-headline text-on-surface tracking-tight">
+          <h1 className="font-headline text-xl font-extrabold tracking-tight text-on-surface">
             Final Breakdown
           </h1>
-          <p className="text-on-surface-variant text-xs mt-0.5">
-            Review the consolidated total or individual receipt details.
+          <p className="mt-0.5 text-xs text-on-surface-variant">
+            Review the consolidated grand total or individual receipt details.
           </p>
         </div>
 
@@ -220,9 +171,9 @@ export function SummaryStep({
       {/* Discrepancy notice */}
       {reconciliationCents !== null && reconciliationCents !== 0 && (
         <div className="mb-8">
-          <div className="bg-error-container/30 border border-error/20 rounded-2xl p-6 flex flex-col md:flex-row items-center justify-between gap-4">
+          <div className="flex flex-col items-center justify-between gap-4 rounded-2xl border border-error/20 bg-error-container/30 p-6 md:flex-row">
             <div className="flex items-center gap-4">
-              <div className="w-12 h-12 rounded-full bg-error-container flex items-center justify-center text-on-error-container flex-shrink-0">
+              <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-error-container text-on-error-container">
                 <span
                   className="material-symbols-outlined"
                   style={{ fontVariationSettings: "'FILL' 1" }}
@@ -243,7 +194,7 @@ export function SummaryStep({
               <button
                 type="button"
                 onClick={onApplyDiscount}
-                className="whitespace-nowrap bg-on-error-container text-on-primary px-6 py-2.5 rounded-xl font-bold text-sm hover:opacity-90 transition-opacity"
+                className="rounded-xl bg-on-error-container px-6 py-2.5 text-sm font-bold whitespace-nowrap text-on-primary transition-opacity hover:opacity-90"
               >
                 Apply Corrective Discount
               </button>
@@ -253,17 +204,42 @@ export function SummaryStep({
       )}
 
       {/* Main two-column layout */}
-      <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 mb-12">
-        {/* Left: Person cards (single column) */}
-        <div className="lg:col-span-8 order-2 lg:order-1">
-          <div className="flex items-center justify-between mb-3">
-            {isForeignCurrency || (activeTab === 'total' && hasAnyForeignReceipt) ? (
-              <CurrencyToggle
-                showBaseCurrency={showBaseCurrency}
-                onToggle={setShowBaseCurrency}
-                activeTab={activeTab}
-                currentCurrency={currentCurrency}
-              />
+      <div className="mb-12 grid grid-cols-1 gap-8 lg:grid-cols-12">
+        {/* Left: Person cards */}
+        <div className="order-2 lg:order-1 lg:col-span-8">
+          <div className="mb-3 flex items-center justify-between">
+            {showCurrencyControls ? (
+              <div className="flex flex-wrap items-center gap-4">
+                <CurrencyToggle
+                  showBaseCurrency={showBaseCurrency}
+                  onToggle={setShowBaseCurrency}
+                  activeTab={activeTab}
+                  currentCurrency={nativeCurrency}
+                />
+                {view.kind === 'total' && view.foreignRates.length > 0 ? (
+                  <div className="flex items-center gap-1.5 text-xs text-on-surface-variant">
+                    <span className="material-symbols-outlined text-sm">currency_exchange</span>
+                    <span>
+                      {view.foreignRates.map(({ currency, rate, hasCustomRate }, i) => (
+                        <span key={currency}>
+                          {i > 0 && <span className="mx-1 opacity-40">·</span>}1 {BASE_CURRENCY} ={' '}
+                          {parseFloat((1 / rate).toFixed(5))} {currency}
+                          {hasCustomRate ? ' (custom)' : ''}
+                        </span>
+                      ))}
+                    </span>
+                  </div>
+                ) : view.kind === 'receipt' && view.effectiveRate ? (
+                  <div className="flex items-center gap-1.5 text-xs text-on-surface-variant">
+                    <span className="material-symbols-outlined text-sm">currency_exchange</span>
+                    <span>
+                      1 {BASE_CURRENCY} = {parseFloat((1 / view.effectiveRate).toFixed(5))}{' '}
+                      {view.nativeCurrency}
+                      {view.receipt?.exchangeRateOverride ? ' (custom rate)' : ''}
+                    </span>
+                  </div>
+                ) : null}
+              </div>
             ) : (
               <span />
             )}
@@ -271,7 +247,7 @@ export function SummaryStep({
               type="button"
               data-testid="summary-show-details-btn"
               onClick={() => setShowDetails((v) => !v)}
-              className="flex items-center gap-1.5 text-sm font-semibold text-on-surface-variant hover:text-primary transition-colors"
+              className="flex items-center gap-1.5 text-sm font-semibold text-on-surface-variant transition-colors hover:text-primary"
             >
               <span className="material-symbols-outlined text-base">
                 {showDetails ? 'expand_less' : 'expand_more'}
@@ -279,39 +255,33 @@ export function SummaryStep({
               {showDetails ? 'Hide details' : 'Show details'}
             </button>
           </div>
+
           <div className="flex flex-col gap-6">
             {people.map((person, index) => (
               <PersonCard
                 key={person.id}
                 person={person}
                 colorIndex={index}
-                split={displaySplit}
-                discount={currentDiscount}
-                serviceCharge={currentServiceCharge}
-                gst={currentGst}
+                split={view.displaySplit}
+                discount={view.discount}
+                serviceCharge={view.serviceCharge}
+                gst={view.gst}
                 showDetails={showDetails}
-                currency={displayCurrency}
-                qrDataUrl={qrDataUrls[person.id]}
-                receiptBreakdown={
-                  activeTab === 'total' && isMultiReceipt
-                    ? receipts.map((r, i) => {
-                        const receiptCurrency = r.currency ?? BASE_CURRENCY;
-                        const usedSplit = showBaseCurrency
-                          ? convertedSplitByReceipt[i]
-                          : splitByReceipt[i];
-                        const usedCurrency = showBaseCurrency ? BASE_CURRENCY : receiptCurrency;
-                        return {
-                          name: r.name || `Receipt ${i + 1}`,
-                          split: usedSplit,
-                          currency: usedCurrency,
-                        };
-                      })
+                currency={view.displayCurrency}
+                conversionRate={
+                  view.kind === 'receipt' && view.isForeign
+                    ? (view.effectiveRate ?? undefined)
                     : undefined
                 }
+                fromCurrency={
+                  view.kind === 'receipt' && view.isForeign ? view.nativeCurrency : undefined
+                }
+                qrDataUrl={qrDataUrls[person.id]}
+                receiptBreakdown={view.kind === 'total' ? view.receiptBreakdowns : undefined}
               />
             ))}
             {people.length === 0 && (
-              <p className="text-center text-on-surface-variant text-sm py-8">
+              <p className="py-8 text-center text-sm text-on-surface-variant">
                 Add people to see the breakdown.
               </p>
             )}
@@ -319,11 +289,11 @@ export function SummaryStep({
         </div>
 
         {/* Right: Grand total + export */}
-        <div className="lg:col-span-4 flex flex-col gap-4 order-1 lg:order-2">
+        <div className="order-1 flex flex-col gap-4 lg:order-2 lg:col-span-4">
           <GrandTotalCard
-            grandTotal={grandTotal}
-            displayCurrency={displayCurrency}
-            currentReceipt={currentReceipt ?? null}
+            grandTotal={view.grandTotal}
+            displayCurrency={view.displayCurrency}
+            currentReceipt={receiptForExport}
             people={people}
             onRenameReceipt={onRenameReceipt}
           />
@@ -339,12 +309,12 @@ export function SummaryStep({
       </div>
 
       {/* Add receipt secondary action */}
-      <div className="flex justify-center mb-4">
+      <div className="mb-4 flex justify-center">
         <button
           type="button"
           data-testid="summary-add-receipt-btn"
           onClick={onAddReceipt}
-          className="flex items-center gap-2 text-sm font-semibold text-on-surface-variant hover:text-primary transition-colors"
+          className="flex items-center gap-2 text-sm font-semibold text-on-surface-variant transition-colors hover:text-primary"
         >
           <span className="material-symbols-outlined text-base">add_box</span>
           Add new receipt

--- a/src/pages/components/workspace/steps/SummaryStep.tsx
+++ b/src/pages/components/workspace/steps/SummaryStep.tsx
@@ -217,18 +217,7 @@ export function SummaryStep({
                   currentCurrency={nativeCurrency}
                 />
                 {view.kind === 'total' && view.foreignRates.length > 0 ? (
-                  <div className="flex items-center gap-1.5 text-xs text-on-surface-variant">
-                    <span className="material-symbols-outlined text-sm">currency_exchange</span>
-                    <span>
-                      {view.foreignRates.map(({ currency, rate, hasCustomRate }, i) => (
-                        <span key={currency}>
-                          {i > 0 && <span className="mx-1 opacity-40">·</span>}1 {BASE_CURRENCY} ={' '}
-                          {parseFloat((1 / rate).toFixed(5))} {currency}
-                          {hasCustomRate ? ' (custom)' : ''}
-                        </span>
-                      ))}
-                    </span>
-                  </div>
+                  <></>
                 ) : view.kind === 'receipt' && view.effectiveRate ? (
                   <div className="flex items-center gap-1.5 text-xs text-on-surface-variant">
                     <span className="material-symbols-outlined text-sm">currency_exchange</span>
@@ -269,12 +258,14 @@ export function SummaryStep({
                 showDetails={showDetails}
                 currency={view.displayCurrency}
                 conversionRate={
-                  view.kind === 'receipt' && view.isForeign
+                  view.kind === 'receipt' && view.isForeign && !showBaseCurrency
                     ? (view.effectiveRate ?? undefined)
                     : undefined
                 }
                 fromCurrency={
-                  view.kind === 'receipt' && view.isForeign ? view.nativeCurrency : undefined
+                  view.kind === 'receipt' && view.isForeign && !showBaseCurrency
+                    ? view.nativeCurrency
+                    : undefined
                 }
                 qrDataUrl={qrDataUrls[person.id]}
                 receiptBreakdown={view.kind === 'total' ? view.receiptBreakdowns : undefined}

--- a/src/pages/components/workspace/steps/SummaryTabs.tsx
+++ b/src/pages/components/workspace/steps/SummaryTabs.tsx
@@ -26,17 +26,17 @@ export function SummaryTabs({ receipts, activeTab, onTabChange, onRenameReceipt 
   };
 
   return (
-    <div className="flex overflow-x-auto gap-3 pb-1" style={{ scrollbarWidth: 'none' }}>
+    <div className="flex gap-3 overflow-x-auto pb-1" style={{ scrollbarWidth: 'none' }}>
       <button
         type="button"
         data-testid="summary-tab-total"
         data-active={activeTab === 'total' ? 'true' : undefined}
         onClick={() => onTabChange('total')}
         className={cn(
-          'flex-shrink-0 px-6 py-2.5 rounded-full font-bold transition-all',
+          'flex-shrink-0 rounded-full px-6 py-2.5 font-bold transition-all',
           activeTab === 'total'
             ? 'bg-primary text-on-primary shadow-md shadow-primary/20'
-            : 'bg-surface-container-high text-on-surface-variant font-semibold hover:bg-surface-container-highest',
+            : 'bg-surface-container-high font-semibold text-on-surface-variant hover:bg-surface-container-highest',
         )}
       >
         Total ({receipts.length} receipts)
@@ -49,7 +49,7 @@ export function SummaryTabs({ receipts, activeTab, onTabChange, onRenameReceipt 
           onClick={() => onTabChange(r.id)}
           onDoubleClick={() => startEditingTab(r.id, r.name || `Receipt ${index + 1}`)}
           className={cn(
-            'flex-shrink-0 flex items-center gap-1.5 px-6 py-2.5 rounded-full font-semibold transition-all cursor-pointer select-none',
+            'flex flex-shrink-0 cursor-pointer items-center gap-1.5 rounded-full px-6 py-2.5 font-semibold transition-all select-none',
             activeTab === r.id
               ? 'bg-primary text-on-primary shadow-md shadow-primary/20'
               : 'bg-surface-container-high text-on-surface-variant hover:bg-surface-container-highest',
@@ -67,7 +67,7 @@ export function SummaryTabs({ receipts, activeTab, onTabChange, onRenameReceipt 
               }}
               onClick={(e) => e.stopPropagation()}
               size={Math.max(editingTabName.length, 6)}
-              className="bg-transparent outline-none font-semibold text-on-primary"
+              className="bg-transparent font-semibold text-on-primary outline-none"
               autoFocus
             />
           ) : (

--- a/src/pages/components/workspace/steps/useSummaryView.ts
+++ b/src/pages/components/workspace/steps/useSummaryView.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import type { ChargeState, Person, Receipt, SplitResult } from '@shared/types';
+import { useCurrencyStore } from '@shared/stores/currencyStore';
+import { useReceiptStore } from '@shared/stores/receiptStore';
+import { generatePaynowQrDataUrls } from '@shared/logic/core/paynowQr';
+import { resolveSummaryView } from '@pages/logic/summaryView';
+import type { SummaryView } from '@pages/logic/summaryView';
+
+export type { SummaryView };
+
+function useQrDataUrls(
+  people: Person[],
+  sgdSplit: SplitResult,
+  payerMobile: string,
+): Record<string, string> {
+  const [qrDataUrls, setQrDataUrls] = useState<Record<string, string>>({});
+
+  const qrAmountsKey = people
+    .map((p) => `${p.id}:${sgdSplit.totalByPersonCents[p.id] ?? 0}`)
+    .join(',');
+
+  useEffect(() => {
+    let cancelled = false;
+    generatePaynowQrDataUrls(people, sgdSplit, payerMobile).then((urls) => {
+      if (!cancelled) setQrDataUrls(urls);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // qrAmountsKey encodes every person's SGD amount, so it covers `people` and
+    // `sgdSplit` transitively — no need to list them directly.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [payerMobile, qrAmountsKey]);
+
+  return qrDataUrls;
+}
+
+type Props = {
+  people: Person[];
+  receipts: Receipt[];
+  split: SplitResult;
+  consolidatedSplit: SplitResult;
+  splitByReceipt: SplitResult[];
+  discount: ChargeState;
+  serviceCharge: ChargeState;
+  gst: ChargeState;
+  activeTab: string;
+  showBaseCurrency: boolean;
+};
+
+export function useSummaryView({
+  people,
+  receipts,
+  split,
+  consolidatedSplit,
+  splitByReceipt,
+  discount,
+  serviceCharge,
+  gst,
+  activeTab,
+  showBaseCurrency,
+}: Props) {
+  const payerMobile = useReceiptStore((s) => s.payerMobile);
+  const exchangeRates = useCurrencyStore((s) => s.exchangeRates);
+
+  const view = resolveSummaryView({
+    receipts,
+    splitByReceipt,
+    consolidatedSplit,
+    fallbackSplit: split,
+    discount,
+    serviceCharge,
+    gst,
+    exchangeRates,
+    activeTab,
+    showBaseCurrency,
+  });
+
+  const qrDataUrls = useQrDataUrls(people, view.sgdSplit, payerMobile);
+
+  return { view, qrDataUrls };
+}

--- a/src/pages/logic/summaryView.test.ts
+++ b/src/pages/logic/summaryView.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it } from 'vitest';
+import type { ChargeState, Receipt, SplitResult } from '@shared/types';
+import { resolveSummaryView } from '@pages/logic/summaryView';
+import type { ResolveSummaryViewInput } from '@pages/logic/summaryView';
+
+const rates: Record<string, number> = { SGD: 1, USD: 1.35, JPY: 0.009 };
+
+function makeCharge(overrides: Partial<ChargeState> = {}): ChargeState {
+  return {
+    enabled: false,
+    mode: 'percent',
+    amountInput: '',
+    percentInput: '',
+    detectedConfidence: null,
+    detectedSource: null,
+    ...overrides,
+  };
+}
+
+function makeReceipt(id: string, currency = 'SGD', override: number | null = null): Receipt {
+  return {
+    id,
+    name: `Receipt ${id}`,
+    items: [],
+    discount: makeCharge({ percentInput: '5' }),
+    serviceCharge: makeCharge({ enabled: true, percentInput: '10' }),
+    gst: makeCharge({ enabled: true, percentInput: '9' }),
+    receiptTotalInput: '',
+    currency,
+    exchangeRateOverride: override,
+  };
+}
+
+function makeSplit(total: number): SplitResult {
+  return {
+    lineItemsByPerson: {},
+    involvedCountByPerson: {},
+    subtotalByPersonCents: { p1: total },
+    discountByPersonCents: { p1: 0 },
+    serviceByPersonCents: { p1: 0 },
+    gstByPersonCents: { p1: 0 },
+    totalByPersonCents: { p1: total },
+    subtotalCents: total,
+    discountCents: 0,
+    serviceChargeCents: 0,
+    gstCents: 0,
+    grandTotalCents: total,
+    unassignedItemCount: 0,
+  };
+}
+
+const globalDiscount = makeCharge({ percentInput: '0' });
+const globalServiceCharge = makeCharge({ enabled: true, percentInput: '10' });
+const globalGst = makeCharge({ enabled: true, percentInput: '9' });
+
+function makeInput(overrides: Partial<ResolveSummaryViewInput> = {}): ResolveSummaryViewInput {
+  return {
+    receipts: [],
+    splitByReceipt: [],
+    consolidatedSplit: makeSplit(0),
+    fallbackSplit: makeSplit(0),
+    discount: globalDiscount,
+    serviceCharge: globalServiceCharge,
+    gst: globalGst,
+    exchangeRates: rates,
+    activeTab: 'total',
+    showBaseCurrency: false,
+    ...overrides,
+  };
+}
+
+// ─── Total tab ────────────────────────────────────────────────────────────────
+
+describe('resolveSummaryView — total tab', () => {
+  it('returns kind:total with consolidatedSplit as displaySplit', () => {
+    const consolidated = makeSplit(3000);
+    const view = resolveSummaryView(
+      makeInput({ consolidatedSplit: consolidated, activeTab: 'total' }),
+    );
+    expect(view.kind).toBe('total');
+    if (view.kind !== 'total') return;
+    expect(view.displaySplit).toBe(consolidated);
+    expect(view.displayCurrency).toBe('SGD');
+  });
+
+  it('uses global charges on total tab', () => {
+    const view = resolveSummaryView(makeInput({ activeTab: 'total' }));
+    expect(view.discount).toBe(globalDiscount);
+    expect(view.serviceCharge).toBe(globalServiceCharge);
+    expect(view.gst).toBe(globalGst);
+  });
+
+  it('computes grandTotal from consolidatedSplit', () => {
+    const view = resolveSummaryView(
+      makeInput({ consolidatedSplit: makeSplit(5000), activeTab: 'total' }),
+    );
+    expect(view.grandTotal).toBe(5000);
+  });
+
+  it('sgdSplit equals consolidatedSplit on total tab', () => {
+    const consolidated = makeSplit(3000);
+    const view = resolveSummaryView(
+      makeInput({ consolidatedSplit: consolidated, activeTab: 'total' }),
+    );
+    expect(view.sgdSplit).toBe(consolidated);
+  });
+
+  it('hasAnyForeign is true when at least one receipt is non-SGD', () => {
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [makeReceipt('r1', 'SGD'), makeReceipt('r2', 'USD')],
+        splitByReceipt: [makeSplit(1000), makeSplit(500)],
+        activeTab: 'total',
+      }),
+    );
+    if (view.kind !== 'total') return;
+    expect(view.hasAnyForeign).toBe(true);
+  });
+
+  it('hasAnyForeign is false when all receipts are SGD', () => {
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [makeReceipt('r1'), makeReceipt('r2')],
+        splitByReceipt: [makeSplit(1000), makeSplit(2000)],
+        activeTab: 'total',
+      }),
+    );
+    if (view.kind !== 'total') return;
+    expect(view.hasAnyForeign).toBe(false);
+  });
+
+  it('foreignRates lists distinct foreign currencies', () => {
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [makeReceipt('r1', 'USD'), makeReceipt('r2', 'JPY'), makeReceipt('r3', 'USD')],
+        splitByReceipt: [makeSplit(500), makeSplit(50000), makeSplit(200)],
+        activeTab: 'total',
+      }),
+    );
+    if (view.kind !== 'total') return;
+    expect(view.foreignRates.map((r) => r.currency)).toEqual(['USD', 'JPY']);
+  });
+
+  it('receiptBreakdowns uses native currency when showBaseCurrency=false', () => {
+    const r1 = makeReceipt('r1', 'USD');
+    const s1 = makeSplit(500);
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [r1],
+        splitByReceipt: [s1],
+        activeTab: 'total',
+        showBaseCurrency: false,
+      }),
+    );
+    if (view.kind !== 'total') return;
+    expect(view.receiptBreakdowns[0].currency).toBe('USD');
+    expect(view.receiptBreakdowns[0].split).toBe(s1);
+  });
+
+  it('receiptBreakdowns uses SGD when showBaseCurrency=true', () => {
+    const r1 = makeReceipt('r1', 'USD');
+    const s1 = makeSplit(500); // 500 USD cents
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [r1],
+        splitByReceipt: [s1],
+        activeTab: 'total',
+        showBaseCurrency: true,
+      }),
+    );
+    if (view.kind !== 'total') return;
+    expect(view.receiptBreakdowns[0].currency).toBe('SGD');
+    // 500 USD cents * 1.35 = 675 SGD cents
+    expect(view.receiptBreakdowns[0].split.totalByPersonCents.p1).toBe(675);
+  });
+});
+
+// ─── Receipt tab ──────────────────────────────────────────────────────────────
+
+describe('resolveSummaryView — receipt tab', () => {
+  const r1 = makeReceipt('r1', 'SGD');
+  const r2 = makeReceipt('r2', 'USD');
+  const sgdSplit = makeSplit(1000);
+  const usdSplit = makeSplit(500);
+
+  it('returns kind:receipt with native split and currency for SGD receipt', () => {
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [r1],
+        splitByReceipt: [sgdSplit],
+        activeTab: 'r1',
+      }),
+    );
+    expect(view.kind).toBe('receipt');
+    if (view.kind !== 'receipt') return;
+    expect(view.receipt).toBe(r1);
+    expect(view.isForeign).toBe(false);
+    expect(view.displaySplit).toBe(sgdSplit);
+    expect(view.displayCurrency).toBe('SGD');
+    expect(view.effectiveRate).toBeNull();
+  });
+
+  it('uses receipt charges over global charges', () => {
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [r1],
+        splitByReceipt: [sgdSplit],
+        activeTab: 'r1',
+      }),
+    );
+    if (view.kind !== 'receipt') return;
+    expect(view.discount).toBe(r1.discount);
+    expect(view.serviceCharge).toBe(r1.serviceCharge);
+    expect(view.gst).toBe(r1.gst);
+  });
+
+  it('foreign receipt with showBaseCurrency=false: displaySplit in native currency', () => {
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [r2],
+        splitByReceipt: [usdSplit],
+        activeTab: 'r2',
+        showBaseCurrency: false,
+      }),
+    );
+    if (view.kind !== 'receipt') return;
+    expect(view.isForeign).toBe(true);
+    expect(view.displaySplit).toBe(usdSplit);
+    expect(view.displayCurrency).toBe('USD');
+    expect(view.effectiveRate).toBe(1.35);
+  });
+
+  it('foreign receipt with showBaseCurrency=true: displaySplit converted to SGD', () => {
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [r2],
+        splitByReceipt: [usdSplit],
+        activeTab: 'r2',
+        showBaseCurrency: true,
+      }),
+    );
+    if (view.kind !== 'receipt') return;
+    expect(view.displayCurrency).toBe('SGD');
+    // 500 USD cents * 1.35 = 675 SGD cents
+    expect(view.displaySplit.totalByPersonCents.p1).toBe(675);
+  });
+
+  it('sgdSplit is converted to SGD for foreign receipt', () => {
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [r2],
+        splitByReceipt: [usdSplit],
+        activeTab: 'r2',
+      }),
+    );
+    if (view.kind !== 'receipt') return;
+    expect(view.sgdSplit.totalByPersonCents.p1).toBe(675);
+  });
+
+  it('sgdSplit equals nativeSplit for SGD receipt', () => {
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [r1],
+        splitByReceipt: [sgdSplit],
+        activeTab: 'r1',
+      }),
+    );
+    if (view.kind !== 'receipt') return;
+    expect(view.sgdSplit).toBe(sgdSplit);
+  });
+
+  it('uses override rate when set on receipt', () => {
+    const r3 = makeReceipt('r3', 'USD', 1.5);
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [r3],
+        splitByReceipt: [usdSplit],
+        activeTab: 'r3',
+      }),
+    );
+    if (view.kind !== 'receipt') return;
+    expect(view.effectiveRate).toBe(1.5);
+    // 500 cents * 1.5 = 750 SGD cents
+    expect(view.sgdSplit.totalByPersonCents.p1).toBe(750);
+  });
+
+  it('falls back to fallbackSplit and null receipt when activeTab matches nothing', () => {
+    const fallback = makeSplit(9999);
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [r1],
+        splitByReceipt: [sgdSplit],
+        fallbackSplit: fallback,
+        activeTab: 'unknown-id',
+      }),
+    );
+    if (view.kind !== 'receipt') return;
+    expect(view.receipt).toBeNull();
+    expect(view.displaySplit).toBe(fallback);
+  });
+
+  it('grandTotal is computed from displaySplit', () => {
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [r1],
+        splitByReceipt: [sgdSplit],
+        activeTab: 'r1',
+      }),
+    );
+    expect(view.grandTotal).toBe(1000);
+  });
+});

--- a/src/pages/logic/summaryView.test.ts
+++ b/src/pages/logic/summaryView.test.ts
@@ -173,6 +173,73 @@ describe('resolveSummaryView — total tab', () => {
     // 500 USD cents * 1.35 = 675 SGD cents
     expect(view.receiptBreakdowns[0].split.totalByPersonCents.p1).toBe(675);
   });
+
+  it('uses BASE_CURRENCY when receipt slot is missing from receipts (splitByReceipt longer)', () => {
+    // splitByReceipt longer than receipts → receipts[i]?.currency is undefined → ?? BASE_CURRENCY
+    const s1 = makeSplit(500);
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [],
+        splitByReceipt: [s1],
+        activeTab: 'total',
+      }),
+    );
+    expect(view.kind).toBe('total');
+    if (view.kind !== 'total') return;
+    expect(view.receiptBreakdowns).toHaveLength(0);
+  });
+
+  it('uses "Receipt N" name when receipt name is empty', () => {
+    const r1 = { ...makeReceipt('r1', 'SGD'), name: '' };
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [r1],
+        splitByReceipt: [makeSplit(1000)],
+        activeTab: 'total',
+      }),
+    );
+    if (view.kind !== 'total') return;
+    expect(view.receiptBreakdowns[0].name).toBe('Receipt 1');
+  });
+
+  it('falls back to splitByReceipt[i] when sgdSplitByReceipt[i] is undefined (receipts longer than splits)', () => {
+    // receipts.length > splitByReceipt.length with showBaseCurrency=true:
+    // sgdSplitByReceipt is built from splitByReceipt.map(), so sgdSplitByReceipt[1] is undefined
+    // → the ?? splitByReceipt[i] fallback branch is exercised
+    const r1 = makeReceipt('r1', 'USD');
+    const r2 = makeReceipt('r2', 'SGD');
+    const s1 = makeSplit(500);
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [r1, r2],
+        splitByReceipt: [s1], // only 1 split for 2 receipts
+        activeTab: 'total',
+        showBaseCurrency: true,
+      }),
+    );
+    if (view.kind !== 'total') return;
+    expect(view.receiptBreakdowns).toHaveLength(2);
+    expect(view.receiptBreakdowns[0].currency).toBe('SGD');
+  });
+
+  it('treats receipt with null currency as SGD (defensive runtime check)', () => {
+    const r1 = { ...makeReceipt('r1', 'SGD'), currency: null as unknown as string };
+    const r2 = makeReceipt('r2', 'USD');
+    const view = resolveSummaryView(
+      makeInput({
+        receipts: [r1, r2],
+        splitByReceipt: [makeSplit(1000), makeSplit(500)],
+        activeTab: 'total',
+        showBaseCurrency: false,
+      }),
+    );
+    if (view.kind !== 'total') return;
+    // null ?? BASE_CURRENCY → 'SGD', so r1 is not foreign
+    expect(view.receiptBreakdowns[0].currency).toBe('SGD');
+    expect(view.receiptBreakdowns[0].effectiveRate).toBeUndefined();
+    // hasAnyForeign should still be true because r2 is USD
+    expect(view.hasAnyForeign).toBe(true);
+  });
 });
 
 // ─── Receipt tab ──────────────────────────────────────────────────────────────

--- a/src/pages/logic/summaryView.ts
+++ b/src/pages/logic/summaryView.ts
@@ -25,7 +25,12 @@ export interface TotalTabView extends BaseView {
   hasAnyForeign: boolean;
   foreignRates: ForeignCurrencyRate[];
   /** Per-receipt breakdown shown inside each PersonCard on the consolidated tab. */
-  receiptBreakdowns: { name: string; split: SplitResult; currency: string }[];
+  receiptBreakdowns: {
+    name: string;
+    split: SplitResult;
+    currency: string;
+    effectiveRate?: number;
+  }[];
 }
 
 export interface ReceiptTabView extends BaseView {
@@ -79,11 +84,19 @@ function resolveTotalTab({
       : s;
   });
 
-  const receiptBreakdowns = receipts.map((r, i) => ({
-    name: r.name || `Receipt ${i + 1}`,
-    split: (showBaseCurrency ? sgdSplitByReceipt[i] : splitByReceipt[i]) ?? splitByReceipt[i],
-    currency: showBaseCurrency ? BASE_CURRENCY : (r.currency ?? BASE_CURRENCY),
-  }));
+  const receiptBreakdowns = receipts.map((r, i) => {
+    const currency = showBaseCurrency ? BASE_CURRENCY : (r.currency ?? BASE_CURRENCY);
+    const isForeign = (r.currency ?? BASE_CURRENCY) !== BASE_CURRENCY;
+    return {
+      name: r.name || `Receipt ${i + 1}`,
+      split: (showBaseCurrency ? sgdSplitByReceipt[i] : splitByReceipt[i]) ?? splitByReceipt[i],
+      currency,
+      effectiveRate:
+        !showBaseCurrency && isForeign
+          ? getEffectiveRate(r.currency!, exchangeRates, r.exchangeRateOverride ?? null)
+          : undefined,
+    };
+  });
 
   return {
     kind: 'total',

--- a/src/pages/logic/summaryView.ts
+++ b/src/pages/logic/summaryView.ts
@@ -1,0 +1,154 @@
+import type { ChargeState, Receipt, SplitResult } from '@shared/types';
+import { BASE_CURRENCY } from '@shared/constants';
+import {
+  convertSplitResult,
+  getEffectiveRate,
+  getForeignReceiptRates,
+} from '@shared/logic/core/exchangeRates';
+import type { ForeignCurrencyRate } from '@shared/logic/core/exchangeRates';
+
+export type { ForeignCurrencyRate };
+
+interface BaseView {
+  displaySplit: SplitResult;
+  displayCurrency: string;
+  grandTotal: number;
+  discount: ChargeState;
+  serviceCharge: ChargeState;
+  gst: ChargeState;
+  /** Always in SGD — used for QR generation and PayNow amounts. */
+  sgdSplit: SplitResult;
+}
+
+export interface TotalTabView extends BaseView {
+  kind: 'total';
+  hasAnyForeign: boolean;
+  foreignRates: ForeignCurrencyRate[];
+  /** Per-receipt breakdown shown inside each PersonCard on the consolidated tab. */
+  receiptBreakdowns: { name: string; split: SplitResult; currency: string }[];
+}
+
+export interface ReceiptTabView extends BaseView {
+  kind: 'receipt';
+  receipt: Receipt | null;
+  nativeCurrency: string;
+  isForeign: boolean;
+  effectiveRate: number | null;
+}
+
+export type SummaryView = TotalTabView | ReceiptTabView;
+
+export type ResolveSummaryViewInput = {
+  receipts: Receipt[];
+  splitByReceipt: SplitResult[];
+  consolidatedSplit: SplitResult;
+  /** Fallback split used when activeTab doesn't match any receipt id. */
+  fallbackSplit: SplitResult;
+  discount: ChargeState;
+  serviceCharge: ChargeState;
+  gst: ChargeState;
+  exchangeRates: Record<string, number>;
+  activeTab: string;
+  showBaseCurrency: boolean;
+};
+
+function grandTotalOf(split: SplitResult): number {
+  return Object.values(split.totalByPersonCents).reduce((s, v) => s + v, 0);
+}
+
+function resolveTotalTab({
+  receipts,
+  splitByReceipt,
+  consolidatedSplit,
+  discount,
+  serviceCharge,
+  gst,
+  exchangeRates,
+  showBaseCurrency,
+}: ResolveSummaryViewInput): TotalTabView {
+  const sgdSplitByReceipt = splitByReceipt.map((s, i) => {
+    const currency = receipts[i]?.currency ?? BASE_CURRENCY;
+    return currency !== BASE_CURRENCY
+      ? convertSplitResult(
+          s,
+          currency,
+          BASE_CURRENCY,
+          exchangeRates,
+          receipts[i]?.exchangeRateOverride ?? null,
+        )
+      : s;
+  });
+
+  const receiptBreakdowns = receipts.map((r, i) => ({
+    name: r.name || `Receipt ${i + 1}`,
+    split: (showBaseCurrency ? sgdSplitByReceipt[i] : splitByReceipt[i]) ?? splitByReceipt[i],
+    currency: showBaseCurrency ? BASE_CURRENCY : (r.currency ?? BASE_CURRENCY),
+  }));
+
+  return {
+    kind: 'total',
+    displaySplit: consolidatedSplit,
+    displayCurrency: BASE_CURRENCY,
+    grandTotal: grandTotalOf(consolidatedSplit),
+    discount,
+    serviceCharge,
+    gst,
+    sgdSplit: consolidatedSplit,
+    hasAnyForeign: receipts.some((r) => (r.currency ?? BASE_CURRENCY) !== BASE_CURRENCY),
+    foreignRates: getForeignReceiptRates(receipts, exchangeRates),
+    receiptBreakdowns,
+  };
+}
+
+function resolveReceiptTab({
+  receipts,
+  splitByReceipt,
+  fallbackSplit,
+  discount,
+  serviceCharge,
+  gst,
+  exchangeRates,
+  activeTab,
+  showBaseCurrency,
+}: ResolveSummaryViewInput): ReceiptTabView {
+  const receiptIndex = receipts.findIndex((r) => r.id === activeTab);
+  const receipt = receipts[receiptIndex] ?? null;
+  const nativeSplit = splitByReceipt[receiptIndex] ?? fallbackSplit;
+
+  const nativeCurrency = receipt?.currency ?? BASE_CURRENCY;
+  const isForeign = nativeCurrency !== BASE_CURRENCY;
+
+  const sgdSplit = isForeign
+    ? convertSplitResult(
+        nativeSplit,
+        nativeCurrency,
+        BASE_CURRENCY,
+        exchangeRates,
+        receipt?.exchangeRateOverride ?? null,
+      )
+    : nativeSplit;
+
+  const displaySplit = isForeign && showBaseCurrency ? sgdSplit : nativeSplit;
+  const displayCurrency = isForeign && showBaseCurrency ? BASE_CURRENCY : nativeCurrency;
+
+  return {
+    kind: 'receipt',
+    receipt,
+    displaySplit,
+    displayCurrency,
+    grandTotal: grandTotalOf(displaySplit),
+    discount: receipt?.discount ?? discount,
+    serviceCharge: receipt?.serviceCharge ?? serviceCharge,
+    gst: receipt?.gst ?? gst,
+    sgdSplit,
+    nativeCurrency,
+    isForeign,
+    effectiveRate: isForeign
+      ? getEffectiveRate(nativeCurrency, exchangeRates, receipt?.exchangeRateOverride ?? null)
+      : null,
+  };
+}
+
+export function resolveSummaryView(input: ResolveSummaryViewInput): SummaryView {
+  return input.activeTab === 'total' ? resolveTotalTab(input) : resolveReceiptTab(input);
+}

--- a/src/shared/logic/core/exchangeRates.test.ts
+++ b/src/shared/logic/core/exchangeRates.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import type { SplitResult } from '@shared/types';
+import type { Receipt, SplitResult } from '@shared/types';
 import {
   convertCents,
   convertSplitResult,
   getEffectiveRate,
+  getForeignReceiptRates,
 } from '@shared/logic/core/exchangeRates';
 
 const rates: Record<string, number> = {
@@ -187,5 +188,84 @@ describe('convertSplitResult', () => {
     // 1000 cents * 1.5 = 1500 SGD cents
     expect(result.subtotalCents).toBe(1500);
     expect(result.grandTotalCents).toBe(1500);
+  });
+});
+
+// ─── getForeignReceiptRates ───────────────────────────────────────────────────
+
+function makeReceipt(currency: string, exchangeRateOverride: number | null = null): Receipt {
+  return {
+    id: 'r1',
+    name: 'Receipt',
+    items: [],
+    discount: {
+      enabled: false,
+      mode: 'percent',
+      amountInput: '',
+      percentInput: '',
+      detectedConfidence: null,
+      detectedSource: null,
+    },
+    serviceCharge: {
+      enabled: false,
+      mode: 'percent',
+      amountInput: '',
+      percentInput: '',
+      detectedConfidence: null,
+      detectedSource: null,
+    },
+    gst: {
+      enabled: false,
+      mode: 'percent',
+      amountInput: '',
+      percentInput: '',
+      detectedConfidence: null,
+      detectedSource: null,
+    },
+    receiptTotalInput: '',
+    currency,
+    exchangeRateOverride,
+  };
+}
+
+describe('getForeignReceiptRates', () => {
+  it('returns empty array when all receipts are SGD', () => {
+    const receipts = [makeReceipt('SGD'), makeReceipt('SGD')];
+    expect(getForeignReceiptRates(receipts, rates)).toEqual([]);
+  });
+
+  it('returns one entry per distinct foreign currency', () => {
+    const receipts = [makeReceipt('USD'), makeReceipt('JPY')];
+    const result = getForeignReceiptRates(receipts, rates);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.currency)).toEqual(['USD', 'JPY']);
+  });
+
+  it('deduplicates receipts sharing the same currency', () => {
+    const receipts = [makeReceipt('USD'), makeReceipt('USD')];
+    const result = getForeignReceiptRates(receipts, rates);
+    expect(result).toHaveLength(1);
+    expect(result[0].currency).toBe('USD');
+  });
+
+  it('uses override rate when present', () => {
+    const receipts = [makeReceipt('USD', 1.5)];
+    const result = getForeignReceiptRates(receipts, rates);
+    expect(result[0].rate).toBe(1.5);
+    expect(result[0].hasCustomRate).toBe(true);
+  });
+
+  it('uses rates map rate when no override', () => {
+    const receipts = [makeReceipt('USD')];
+    const result = getForeignReceiptRates(receipts, rates);
+    expect(result[0].rate).toBe(1.35);
+    expect(result[0].hasCustomRate).toBe(false);
+  });
+
+  it('excludes SGD receipts mixed with foreign receipts', () => {
+    const receipts = [makeReceipt('SGD'), makeReceipt('USD'), makeReceipt('SGD')];
+    const result = getForeignReceiptRates(receipts, rates);
+    expect(result).toHaveLength(1);
+    expect(result[0].currency).toBe('USD');
   });
 });

--- a/src/shared/logic/core/exchangeRates.test.ts
+++ b/src/shared/logic/core/exchangeRates.test.ts
@@ -268,4 +268,11 @@ describe('getForeignReceiptRates', () => {
     expect(result).toHaveLength(1);
     expect(result[0].currency).toBe('USD');
   });
+
+  it('treats receipt with null currency as SGD and excludes it (defensive runtime check)', () => {
+    const receipt = { ...makeReceipt('SGD'), currency: null as unknown as string };
+    const result = getForeignReceiptRates([receipt], rates);
+    // null ?? BASE_CURRENCY = 'SGD' → skipped
+    expect(result).toEqual([]);
+  });
 });

--- a/src/shared/logic/core/exchangeRates.ts
+++ b/src/shared/logic/core/exchangeRates.ts
@@ -1,5 +1,5 @@
-import type { SplitResult } from '@shared/types';
-import { FALLBACK_RATES_TO_SGD } from '@shared/constants';
+import type { Receipt, SplitResult } from '@shared/types';
+import { BASE_CURRENCY, FALLBACK_RATES_TO_SGD } from '@shared/constants';
 
 /**
  * Returns the effective exchange rate for a currency to SGD.
@@ -30,6 +30,34 @@ export function convertCents(
   const toSgd = getEffectiveRate(fromCurrency, rates, override);
   const fromSgd = getEffectiveRate(toCurrency, rates, null);
   return Math.round((amountCents * toSgd) / fromSgd);
+}
+
+export type ForeignCurrencyRate = {
+  currency: string;
+  rate: number;
+  hasCustomRate: boolean;
+};
+
+/**
+ * Returns one entry per distinct foreign currency found in `receipts`, using
+ * the effective rate for the first receipt that uses each currency.
+ * SGD receipts are excluded. Used to display rate info on the consolidated tab.
+ */
+export function getForeignReceiptRates(
+  receipts: Receipt[],
+  exchangeRates: Record<string, number>,
+): ForeignCurrencyRate[] {
+  const seen = new Map<string, ForeignCurrencyRate>();
+  for (const receipt of receipts) {
+    const currency = receipt.currency ?? BASE_CURRENCY;
+    if (currency === BASE_CURRENCY || seen.has(currency)) continue;
+    seen.set(currency, {
+      currency,
+      rate: getEffectiveRate(currency, exchangeRates, receipt.exchangeRateOverride),
+      hasCustomRate: receipt.exchangeRateOverride != null,
+    });
+  }
+  return Array.from(seen.values());
 }
 
 /**


### PR DESCRIPTION
## Summary

- Each person's card now shows their approximate SGD equivalent and the exchange rate used, directly below their total, when viewing a foreign-currency receipt in its native currency
- Both lines disappear when the user toggles to SGD view via the currency toggle
- In the multi-receipt Total tab, each receipt breakdown card shows the same info (≈ SGD amount + rate) below its subtotal for foreign receipts
- Renames the currency toggle label from "Original" to "As billed" on the consolidated tab

## Test plan

- [x] Open a foreign-currency receipt in the summary — verify ≈ SGD amount and rate appear below each person's total
- [x] Toggle to SGD view — verify both lines disappear
- [x] With multiple receipts including a foreign one, open the Total tab and expand details — verify each foreign receipt breakdown card shows ≈ SGD and rate below its subtotal
- [x] SGD-only receipts are unaffected (no rate lines shown)
- [x] Custom exchange rate overrides display correctly