### PR TITLE
feat: dev-only image preview modal for split result

### DIFF
--- a/src/features/split-results/logic/receiptSplitImageLightHelpers.ts
+++ b/src/features/split-results/logic/receiptSplitImageLightHelpers.ts
@@ -156,7 +156,7 @@ export function drawLightTwoColumnRow(
   const style = args.italic ? 'italic ' : '';
   const weight = args.emphasized ? 700 : 400;
   const valueFont = `${style}${weight} ${args.size}px system-ui, -apple-system, sans-serif`;
-  const labelFont = `${style}500 ${Math.max(14, args.size - 2)}px system-ui, -apple-system, sans-serif`;
+  const labelFont = `${style}${weight} ${Math.max(14, args.size - 2)}px system-ui, -apple-system, sans-serif`;
 
   ctx.font = valueFont;
   const valueWidth = ctx.measureText(args.value).width;

--- a/src/pages/components/workspace/steps/ExportActions.tsx
+++ b/src/pages/components/workspace/steps/ExportActions.tsx
@@ -1,4 +1,4 @@
-type ExportBusy = 'downloading' | 'copying' | null;
+type ExportBusy = 'downloading' | 'copying' | 'previewing' | null;
 
 interface Props {
   busy: ExportBusy;
@@ -7,6 +7,7 @@ interface Props {
   nativeShareSupported: boolean;
   onDownload: () => void;
   onShare: () => void;
+  onPreview?: () => void;
 }
 
 export function ExportActions({
@@ -16,6 +17,7 @@ export function ExportActions({
   nativeShareSupported,
   onDownload,
   onShare,
+  onPreview,
 }: Props) {
   return (
     <div className="flex flex-col gap-2">
@@ -47,6 +49,17 @@ export function ExportActions({
               ? 'Share'
               : 'Copy Text'}
       </button>
+      {import.meta.env.DEV && onPreview && (
+        <button
+          type="button"
+          onClick={onPreview}
+          disabled={busy !== null}
+          className="flex items-center justify-center gap-2 rounded-xl border border-dashed border-outline-variant/50 px-6 py-3 text-sm font-bold text-on-surface-variant transition-all hover:border-primary hover:text-primary disabled:opacity-60"
+        >
+          <span className="material-symbols-outlined text-base">preview</span>
+          {busy === 'previewing' ? 'Generating…' : 'Preview Image'}
+        </button>
+      )}
       {exportError && <p className="text-sm text-error">{exportError}</p>}
     </div>
   );

--- a/src/pages/components/workspace/steps/ImagePreviewModal.tsx
+++ b/src/pages/components/workspace/steps/ImagePreviewModal.tsx
@@ -1,0 +1,49 @@
+import { useEffect } from 'react';
+import type { KeyboardEvent } from 'react';
+
+interface Props {
+  url: string;
+  onClose: () => void;
+}
+
+export function ImagePreviewModal({ url, onClose }: Props) {
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center p-4"
+      onKeyDown={handleKeyDown}
+    >
+      <div
+        className="absolute inset-0 bg-on-surface/40 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div className="relative flex max-h-[90vh] max-w-5xl flex-col rounded-3xl border border-surface-container-highest bg-surface-container-lowest/90 shadow-[0_8px_24px_rgba(25,28,29,0.12)] backdrop-blur-[20px]">
+        <div className="flex flex-shrink-0 items-center justify-between px-5 py-4">
+          <span className="text-sm font-bold text-on-surface-variant">Image Preview (dev)</span>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="flex h-9 w-9 items-center justify-center rounded-xl text-on-surface-variant transition-colors hover:bg-surface-container-low"
+          >
+            <span className="material-symbols-outlined text-xl">close</span>
+          </button>
+        </div>
+        <div className="overflow-y-auto px-5 pb-5">
+          <img src={url} alt="Split result preview" className="max-w-full rounded-xl" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/components/workspace/steps/SummaryStep.tsx
+++ b/src/pages/components/workspace/steps/SummaryStep.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { ChargeState, Person, Receipt, SplitResult } from '@shared/types';
 import { formatCurrencyFromCents } from '@shared/logic/core/money';
 import { generateReceiptSplitImageLight } from '@features/split-results/logic/receiptSplitImageLight';
@@ -17,6 +17,7 @@ import { SummaryTabs } from './SummaryTabs';
 import { CurrencyToggle } from './CurrencyToggle';
 import { GrandTotalCard } from './GrandTotalCard';
 import { ExportActions } from './ExportActions';
+import { ImagePreviewModal } from './ImagePreviewModal';
 import { useSummaryView } from './useSummaryView';
 
 export type SummaryStepProps = {
@@ -35,7 +36,7 @@ export type SummaryStepProps = {
   onRenameReceipt: (id: string, name: string) => void;
 };
 
-type ExportBusy = 'downloading' | 'copying' | null;
+type ExportBusy = 'downloading' | 'copying' | 'previewing' | null;
 
 export function SummaryStep({
   people,
@@ -56,11 +57,18 @@ export function SummaryStep({
     isMultiReceipt ? 'total' : (receipts[0]?.id ?? 'total'),
   );
   const [busy, setBusy] = useState<ExportBusy>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [showDetails, setShowDetails] = useState(true);
   const [showBaseCurrency, setShowBaseCurrency] = useState(false);
   const [copied, setCopied] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
   const copyTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
 
   const payerMobile = useReceiptStore((s) => s.payerMobile);
   const { view, qrDataUrls } = useSummaryView({
@@ -116,6 +124,43 @@ export function SummaryStep({
       downloadImage(blob, buildDownloadFilename('split', receiptForExport?.name));
     } catch {
       setExportError('Failed to generate image.');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const handlePreview = async () => {
+    setBusy('previewing');
+    setExportError(null);
+    try {
+      const blob = await generateReceiptSplitImageLight({
+        people,
+        split: view.displaySplit,
+        sgdSplit: view.sgdSplit,
+        receipts,
+        splitByReceipt,
+        discount: view.discount,
+        serviceCharge: view.serviceCharge,
+        gst: view.gst,
+        receiptName: receiptForExport?.name,
+        reconciliationCents,
+        includeItemDetails: showDetails,
+        currency: view.displayCurrency,
+        payerMobile: normalizeMobile(payerMobile) ?? undefined,
+        conversionRate:
+          view.kind === 'receipt' && view.isForeign && !showBaseCurrency
+            ? (view.effectiveRate ?? undefined)
+            : undefined,
+        fromCurrency:
+          view.kind === 'receipt' && view.isForeign && !showBaseCurrency
+            ? view.nativeCurrency
+            : undefined,
+        effectiveRatesByReceipt:
+          view.kind === 'total' ? view.receiptBreakdowns.map((b) => b.effectiveRate) : undefined,
+      });
+      setPreviewUrl(URL.createObjectURL(blob));
+    } catch {
+      setExportError('Failed to generate preview.');
     } finally {
       setBusy(null);
     }
@@ -305,6 +350,7 @@ export function SummaryStep({
             nativeShareSupported={nativeShareSupported}
             onDownload={handleDownload}
             onShare={handleShare}
+            onPreview={handlePreview}
           />
         </div>
       </div>
@@ -321,6 +367,7 @@ export function SummaryStep({
           Add new receipt
         </button>
       </div>
+      {previewUrl && <ImagePreviewModal url={previewUrl} onClose={() => setPreviewUrl(null)} />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a **Preview Image** button to the export actions area, visible only in `vite dev` (`import.meta.env.DEV`) — stripped from production builds
- Clicking Preview generates the same image blob as Download and displays it in a modal overlay, eliminating the download-open-inspect loop when iterating on canvas changes
- Fixes `drawLightTwoColumnRow` so receipt names are correctly bolded when `emphasized: true` (label font was hardcoded to weight 500)

## Changes
- `ImagePreviewModal.tsx` — new modal with body scroll lock, `z-[60]` to sit above the bottom nav, and image-only scroll
- `ExportActions.tsx` — optional `onPreview` prop + dev-only dashed button
- `SummaryStep.tsx` — `handlePreview` handler, `previewUrl` state with `URL.revokeObjectURL` cleanup
- `receiptSplitImageLightHelpers.ts` — apply `weight` to label font in `drawLightTwoColumnRow`

## Test plan
- [ ] Click **Preview Image** in `pnpm dev` → modal opens showing the generated image
- [ ] Modal scroll scrolls image only; background page does not scroll
- [ ] Modal sits above the bottom navigation bar
- [ ] Close button and backdrop click both dismiss the modal
- [ ] **Save Image** still triggers a file download (unchanged)
- [ ] **Preview Image** button is absent from production build (`pnpm build`)
- [ ] Receipt names appear bold in the exported image

🤖 Generated with [Claude Code](https://claude.com/claude-code)