### PR TITLE
Add interactive wizard step navigation

### DIFF
--- a/src/features/split-workspace/components/TopAppBar.tsx
+++ b/src/features/split-workspace/components/TopAppBar.tsx
@@ -1,19 +1,14 @@
 import { cn } from '@shared/utils/cn';
 import type { ItemsSubPhase, WizardStep } from '@features/split-workspace/types';
-
-const STEP_ORDER: WizardStep[] = ['people', 'receipt', 'items', 'final'];
-const STEP_LABELS: Record<WizardStep, string> = {
-  people: 'People',
-  receipt: 'Receipt',
-  items: 'Assign',
-  final: 'Summary',
-};
+import { STEP_LABELS, STEP_ORDER } from '@features/split-workspace/logic/wizardSteps';
 
 interface Props {
   activeStep: WizardStep;
   itemsSubPhase: ItemsSubPhase;
   assignedItemCount: number;
   detectedItemsCount: number;
+  stepReachability: Record<WizardStep, boolean>;
+  onStepSelect: (step: WizardStep) => void;
 }
 
 export function TopAppBar({
@@ -21,10 +16,11 @@ export function TopAppBar({
   itemsSubPhase,
   assignedItemCount,
   detectedItemsCount,
+  stepReachability,
+  onStepSelect,
 }: Props) {
   const stepIndex = STEP_ORDER.indexOf(activeStep);
   const stepNumber = stepIndex + 1;
-  const trackFillPercent = (stepNumber / STEP_ORDER.length) * 100;
 
   let contextText = '';
   if (activeStep === 'items') {
@@ -42,22 +38,40 @@ export function TopAppBar({
           Split
         </div>
 
-        {/* Desktop: connected step circles */}
-        <nav className="hidden flex-1 items-center justify-center md:flex">
+        {/* Desktop: connected step buttons */}
+        <nav
+          aria-label="Wizard steps"
+          className="hidden flex-1 items-center justify-center md:flex"
+        >
           {STEP_ORDER.map((step, i) => {
             const completed = i < stepIndex;
             const isCurrent = step === activeStep;
+            const disabled = !stepReachability[step];
             return (
               <div key={step} className="flex items-center">
-                <div className="flex flex-col items-center gap-1">
+                <button
+                  type="button"
+                  data-testid={`wizard-step-nav-${step}`}
+                  onClick={() => onStepSelect(step)}
+                  disabled={disabled}
+                  aria-current={isCurrent ? 'step' : undefined}
+                  className={cn(
+                    'group flex flex-col items-center gap-1 rounded-xl px-2 py-1 transition-all',
+                    disabled
+                      ? 'cursor-not-allowed opacity-45'
+                      : 'hover:bg-surface-container-low active:scale-95',
+                  )}
+                >
                   <div
                     className={cn(
                       'flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold transition-all',
-                      completed
-                        ? 'bg-secondary text-on-secondary'
-                        : isCurrent
-                          ? 'bg-primary text-on-primary ring-4 ring-primary/10'
-                          : 'bg-surface-container-highest text-on-surface-variant',
+                      disabled
+                        ? 'bg-surface-container-highest text-on-surface-variant'
+                        : completed
+                          ? 'bg-secondary text-on-secondary'
+                          : isCurrent
+                            ? 'bg-primary text-on-primary ring-4 ring-primary/10'
+                            : 'bg-surface-container-highest text-on-surface-variant',
                     )}
                   >
                     {completed ? (
@@ -74,16 +88,18 @@ export function TopAppBar({
                   <span
                     className={cn(
                       'text-[9px] font-bold tracking-widest uppercase',
-                      completed
-                        ? 'text-secondary'
-                        : isCurrent
-                          ? 'text-primary'
-                          : 'text-on-surface-variant',
+                      disabled
+                        ? 'text-on-surface-variant'
+                        : completed
+                          ? 'text-secondary'
+                          : isCurrent
+                            ? 'text-primary'
+                            : 'text-on-surface-variant',
                     )}
                   >
                     {STEP_LABELS[step]}
                   </span>
-                </div>
+                </button>
                 {i < STEP_ORDER.length - 1 && (
                   <div
                     className={cn(
@@ -122,13 +138,75 @@ export function TopAppBar({
         </a>
       </div>
 
-      {/* Mobile: thin progress bar */}
-      <div className="h-0.5 bg-surface-container-highest md:hidden">
-        <div
-          className="h-full bg-primary transition-all duration-500"
-          style={{ width: `${trackFillPercent}%` }}
-        />
-      </div>
+      {/* Mobile: compact interactive step buttons */}
+      <nav
+        aria-label="Wizard steps"
+        className="border-t border-surface-container-highest px-3 py-2 md:hidden"
+      >
+        <div className="mx-auto grid max-w-7xl grid-cols-4 gap-1">
+          {STEP_ORDER.map((step, i) => {
+            const completed = i < stepIndex;
+            const isCurrent = step === activeStep;
+            const disabled = !stepReachability[step];
+            return (
+              <button
+                key={step}
+                type="button"
+                data-testid={`wizard-step-nav-mobile-${step}`}
+                onClick={() => onStepSelect(step)}
+                disabled={disabled}
+                aria-current={isCurrent ? 'step' : undefined}
+                className={cn(
+                  'flex min-w-0 flex-col items-center gap-1 rounded-xl px-1.5 py-2 transition-all',
+                  disabled
+                    ? 'cursor-not-allowed opacity-45'
+                    : isCurrent
+                      ? 'bg-primary/10'
+                      : 'active:scale-95',
+                )}
+              >
+                <span
+                  className={cn(
+                    'flex h-6 w-6 items-center justify-center rounded-full text-[10px] font-bold transition-all',
+                    disabled
+                      ? 'bg-surface-container-highest text-on-surface-variant'
+                      : completed
+                        ? 'bg-secondary text-on-secondary'
+                        : isCurrent
+                          ? 'bg-primary text-on-primary ring-4 ring-primary/10'
+                          : 'bg-surface-container-highest text-on-surface-variant',
+                  )}
+                >
+                  {completed ? (
+                    <span
+                      className="material-symbols-outlined text-[10px]"
+                      style={{ fontVariationSettings: "'FILL' 1" }}
+                    >
+                      check
+                    </span>
+                  ) : (
+                    i + 1
+                  )}
+                </span>
+                <span
+                  className={cn(
+                    'truncate text-[9px] font-bold tracking-wider uppercase',
+                    disabled
+                      ? 'text-on-surface-variant'
+                      : completed
+                        ? 'text-secondary'
+                        : isCurrent
+                          ? 'text-primary'
+                          : 'text-on-surface-variant',
+                  )}
+                >
+                  {STEP_LABELS[step]}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </nav>
     </header>
   );
 }

--- a/src/features/split-workspace/components/Workspace.tsx
+++ b/src/features/split-workspace/components/Workspace.tsx
@@ -43,8 +43,10 @@ export function Workspace() {
     setActiveItemIndex,
     setItemsSubPhase,
     canContinue,
+    stepReachability,
     handleNext,
     handleBack,
+    handleStepSelect,
     handleAddReceipt,
   } = useWizard(items, people, normalizeItems, receipts, activeReceiptId, setActiveReceiptId);
 
@@ -70,6 +72,11 @@ export function Workspace() {
     window.scrollTo({ top: 0, behavior: 'instant' });
   };
 
+  const handleStepSelectWithScroll = (step: Parameters<typeof handleStepSelect>[0]) => {
+    handleStepSelect(step);
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  };
+
   if (!activeReceipt) {
     return null;
   }
@@ -84,6 +91,8 @@ export function Workspace() {
         itemsSubPhase={itemsSubPhase}
         assignedItemCount={assignedItemCount}
         detectedItemsCount={detectedItemsCount}
+        stepReachability={stepReachability}
+        onStepSelect={handleStepSelectWithScroll}
       />
 
       <main className="mx-auto w-full max-w-7xl flex-grow px-6 pt-4 pb-48 md:px-8 md:pt-10">

--- a/src/features/split-workspace/hooks/useWizard.ts
+++ b/src/features/split-workspace/hooks/useWizard.ts
@@ -52,6 +52,45 @@ export function useWizard(
       ? itemsSubPhase === 'review' && isStepValid('items', { items, people })
       : isStepValid(activeStep, { items, people });
 
+  const allReceiptItems = receipts.flatMap((receipt) => receipt.items);
+  const canReachReceipt = isStepValid('people', { items, people });
+  const canReachItems = canReachReceipt && isStepValid('receipt', { items, people });
+  const canReachFinal = canReachItems && isStepValid('items', { items: allReceiptItems, people });
+
+  const stepReachability: Record<WizardStep, boolean> = {
+    people: true,
+    receipt: canReachReceipt,
+    items: canReachItems,
+    final: canReachFinal,
+  };
+
+  const handleStepSelect = (targetStep: WizardStep) => {
+    if (!stepReachability[targetStep]) return;
+
+    if (targetStep === 'people') {
+      setActiveStep('people');
+      return;
+    }
+
+    if (targetStep === 'receipt') {
+      setActiveStep('receipt');
+      if (activeStep === 'people' && !geminiApiKeyInput.trim()) setShowApiKeyModal(true);
+      return;
+    }
+
+    if (targetStep === 'items') {
+      normalizeItems();
+      setItemsSubPhase('assign');
+      setActiveItemIndex(0);
+      setActiveStep('items');
+      return;
+    }
+
+    normalizeItems();
+    setItemsSubPhase('review');
+    setActiveStep('final');
+  };
+
   const handleNext = () => {
     if (activeStep === 'people') {
       if (!isStepValid('people', { items, people })) return;
@@ -126,8 +165,10 @@ export function useWizard(
     setActiveItemIndex: (index: number) => setActiveItemIndex(index),
     setItemsSubPhase: (phase: ItemsSubPhase) => setItemsSubPhase(phase),
     canContinue,
+    stepReachability,
     handleNext,
     handleBack,
+    handleStepSelect,
     handleAddReceipt,
   };
 }

--- a/src/pages/ReceiptSplitterPage.test.tsx
+++ b/src/pages/ReceiptSplitterPage.test.tsx
@@ -97,6 +97,14 @@ function clickBack() {
   fireEvent.click(screen.getByTestId('wizard-back-btn'));
 }
 
+function clickStepNav(step: 'people' | 'receipt' | 'items' | 'final') {
+  fireEvent.click(screen.getByTestId(`wizard-step-nav-${step}`));
+}
+
+function expectActiveStepNav(step: 'people' | 'receipt' | 'items' | 'final') {
+  expect(screen.getByTestId(`wizard-step-nav-${step}`)).toHaveAttribute('aria-current', 'step');
+}
+
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
@@ -225,6 +233,88 @@ describe('ReceiptSplitterPage integration', () => {
       clickBack(); // receipt → people
       expect(screen.getByTestId('wizard-step-context')).toHaveTextContent(/Step 1/i);
       expect(screen.queryByTestId('wizard-back-btn')).not.toBeInTheDocument();
+    });
+
+    it('jumps from summary directly back to people through the top nav', async () => {
+      seedV2Draft({});
+      render(<ReceiptSplitterPage />);
+      await waitFor(() => expect(screen.getByTestId('wizard-continue-btn')).not.toBeDisabled());
+
+      clickContinue();
+      clickContinue();
+      clickContinue();
+      clickContinue();
+      expectActiveStepNav('final');
+
+      clickStepNav('people');
+
+      expectActiveStepNav('people');
+      expect(screen.getByTestId('people-list')).toBeInTheDocument();
+    });
+
+    it('jumps from summary directly back to receipt through the top nav', async () => {
+      seedV2Draft({});
+      render(<ReceiptSplitterPage />);
+      await waitFor(() => expect(screen.getByTestId('wizard-continue-btn')).not.toBeDisabled());
+
+      clickContinue();
+      clickContinue();
+      clickContinue();
+      clickContinue();
+      expectActiveStepNav('final');
+
+      clickStepNav('receipt');
+
+      expectActiveStepNav('receipt');
+      expect(screen.getByTestId('receipt-add-item-btn')).toBeInTheDocument();
+    });
+
+    it('jumps from receipt directly to assign when receipt data is valid', async () => {
+      seedV2Draft({});
+      render(<ReceiptSplitterPage />);
+      await waitFor(() => expect(screen.getByTestId('wizard-continue-btn')).not.toBeDisabled());
+
+      clickContinue();
+      expectActiveStepNav('receipt');
+
+      clickStepNav('items');
+
+      expectActiveStepNav('items');
+      expect(screen.getByTestId('assign-item-counter')).toBeInTheDocument();
+    });
+
+    it('jumps from receipt directly to summary when assignments are complete', async () => {
+      seedV2Draft({});
+      render(<ReceiptSplitterPage />);
+      await waitFor(() => expect(screen.getByTestId('wizard-continue-btn')).not.toBeDisabled());
+
+      clickContinue();
+      expectActiveStepNav('receipt');
+
+      clickStepNav('final');
+
+      expectActiveStepNav('final');
+      expect(screen.queryByTestId('wizard-continue-btn')).not.toBeInTheDocument();
+    });
+
+    it('disables top-nav jumps until each step prerequisite is met', () => {
+      render(<ReceiptSplitterPage />);
+
+      expect(screen.getByTestId('wizard-step-nav-receipt')).toBeDisabled();
+      expect(screen.getByTestId('wizard-step-nav-items')).toBeDisabled();
+      expect(screen.getByTestId('wizard-step-nav-final')).toBeDisabled();
+
+      addPeople('Alice, Bob');
+
+      expect(screen.getByTestId('wizard-step-nav-receipt')).not.toBeDisabled();
+      expect(screen.getByTestId('wizard-step-nav-items')).toBeDisabled();
+      expect(screen.getByTestId('wizard-step-nav-final')).toBeDisabled();
+
+      clickStepNav('receipt');
+
+      expectActiveStepNav('receipt');
+      expect(screen.getByTestId('wizard-step-nav-items')).toBeDisabled();
+      expect(screen.getByTestId('wizard-step-nav-final')).toBeDisabled();
     });
 
     it('blocks continue on receipt step until valid items exist', async () => {


### PR DESCRIPTION
## Summary
- Add guarded direct step selection for People, Receipt, Assign, and Summary
- Replace the passive mobile progress bar with compact interactive step buttons
- Cover direct jumps and disabled future steps with integration tests

Closes #56