### PR TITLE
Add split unassigned shortcut

### DIFF
--- a/src/features/split-workspace/components/steps/AssignStep.test.tsx
+++ b/src/features/split-workspace/components/steps/AssignStep.test.tsx
@@ -5,6 +5,7 @@ import {
   defaultGstState,
   defaultServiceChargeState,
 } from '@features/split-workspace/constants';
+import { splitUnassignedItemsEqually } from '@features/split-workspace/logic/assignmentActions';
 import type { EditableItem, Person, Receipt } from '@shared/types';
 import { AssignStep } from './AssignStep';
 
@@ -15,6 +16,7 @@ type AssignStepStoreMock = {
   setActiveReceiptId: ReturnType<typeof vi.fn>;
   renameReceipt: ReturnType<typeof vi.fn>;
   updateItem: ReturnType<typeof vi.fn>;
+  splitUnassignedItemsEquallyForActiveReceipt: ReturnType<typeof vi.fn>;
 };
 
 let storeMock: AssignStepStoreMock;
@@ -38,6 +40,18 @@ function setStoreMock(withSavedWeights = true) {
         {
           ...receipt,
           items: receipt.items.map((item) => (item.id === itemId ? updater(item) : item)),
+        },
+      ],
+    };
+  });
+  const splitUnassignedItemsEquallyForActiveReceipt = vi.fn(() => {
+    const receipt = storeMock.receipts[0];
+    storeMock = {
+      ...storeMock,
+      receipts: [
+        {
+          ...receipt,
+          items: splitUnassignedItemsEqually(receipt.items, storeMock.people),
         },
       ],
     };
@@ -85,6 +99,7 @@ function setStoreMock(withSavedWeights = true) {
     setActiveReceiptId: vi.fn(),
     renameReceipt: vi.fn(),
     updateItem,
+    splitUnassignedItemsEquallyForActiveReceipt,
   };
 }
 
@@ -104,9 +119,10 @@ describe('AssignStep', () => {
       />,
     );
 
-    // Equal item: both toggle buttons shown, weight controls hidden
-    expect(screen.getByRole('button', { name: 'Equal' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Unequal' })).toBeInTheDocument();
+    // Equal item: both split buttons shown, weight controls hidden
+    expect(screen.getByTestId('assign-split-mode-toggle')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Equally' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'By shares' })).not.toBeDisabled();
     expect(screen.queryByText('Share weights')).not.toBeInTheDocument();
 
     rerender(
@@ -126,7 +142,7 @@ describe('AssignStep', () => {
     expect(screen.getByTestId('assign-weight-decrement-p2')).toBeDisabled();
   });
 
-  it('clears saved weights when clicking Equal in unequal mode', () => {
+  it('clears saved weights when clicking Equally in shares mode', () => {
     render(
       <AssignStep
         itemsSubPhase="assign"
@@ -136,10 +152,126 @@ describe('AssignStep', () => {
       />,
     );
 
-    // In unequal mode, click "Equal" to switch back (Unequal button does nothing)
-    fireEvent.click(screen.getByRole('button', { name: 'Equal' }));
+    // In shares mode, click "Equally" to switch back (By shares button does nothing)
+    fireEvent.click(screen.getByRole('button', { name: 'Equally' }));
 
     const weightedItem = storeMock.receipts[0].items[1];
     expect(weightedItem.assignment.weights).toBeUndefined();
+  });
+
+  it('shows the Split control disabled when fewer than two people are selected', () => {
+    storeMock = {
+      ...storeMock,
+      receipts: [
+        {
+          ...storeMock.receipts[0],
+          items: [
+            {
+              ...storeMock.receipts[0].items[0],
+              assignment: { mode: 'equal', personId: '', personIds: ['p1'] },
+            },
+          ],
+        },
+      ],
+    };
+
+    render(
+      <AssignStep
+        itemsSubPhase="assign"
+        activeItemIndex={0}
+        onActiveItemIndexChange={vi.fn()}
+        onItemsSubPhaseChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('assign-split-mode-toggle')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Equally' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'By shares' })).toBeDisabled();
+  });
+
+  it('splits unassigned items equally and jumps to review when clicking Split unassigned', () => {
+    storeMock = {
+      ...storeMock,
+      receipts: [
+        {
+          ...storeMock.receipts[0],
+          items: [
+            ...storeMock.receipts[0].items,
+            {
+              id: 'unassigned-item',
+              name: 'Unassigned item',
+              amountInput: '8.00',
+              discountPercentInput: '',
+              assignment: { mode: 'equal', personId: '', personIds: [] },
+            },
+          ],
+        },
+      ],
+    };
+    const onActiveItemIndexChange = vi.fn();
+    const onItemsSubPhaseChange = vi.fn();
+
+    render(
+      <AssignStep
+        itemsSubPhase="assign"
+        activeItemIndex={0}
+        onActiveItemIndexChange={onActiveItemIndexChange}
+        onItemsSubPhaseChange={onItemsSubPhaseChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('assign-split-rest-btn'));
+
+    expect(storeMock.splitUnassignedItemsEquallyForActiveReceipt).toHaveBeenCalledTimes(1);
+    expect(onActiveItemIndexChange).toHaveBeenCalledWith(0);
+    expect(onItemsSubPhaseChange).toHaveBeenCalledWith('review');
+    expect(storeMock.receipts[0].items[0].assignment.weights).toBeUndefined();
+    expect(storeMock.receipts[0].items[1].assignment.weights).toEqual({ p1: 2, p2: 1 });
+    expect(storeMock.receipts[0].items[2].assignment.personIds).toEqual(['p1', 'p2']);
+  });
+
+  it('disables Split unassigned when all items are already assigned', () => {
+    render(
+      <AssignStep
+        itemsSubPhase="assign"
+        activeItemIndex={0}
+        onActiveItemIndexChange={vi.fn()}
+        onItemsSubPhaseChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('assign-split-rest-btn')).toBeDisabled();
+  });
+
+  it('disables Split unassigned when there are no people', () => {
+    storeMock = {
+      ...storeMock,
+      people: [],
+      receipts: [
+        {
+          ...storeMock.receipts[0],
+          items: [
+            {
+              id: 'unassigned-item',
+              name: 'Unassigned item',
+              amountInput: '8.00',
+              discountPercentInput: '',
+              assignment: { mode: 'equal', personId: '', personIds: [] },
+            },
+          ],
+        },
+      ],
+    };
+
+    render(
+      <AssignStep
+        itemsSubPhase="assign"
+        activeItemIndex={0}
+        onActiveItemIndexChange={vi.fn()}
+        onItemsSubPhaseChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('assign-split-rest-btn')).toBeDisabled();
   });
 });

--- a/src/features/split-workspace/components/steps/AssignStep.tsx
+++ b/src/features/split-workspace/components/steps/AssignStep.tsx
@@ -37,6 +37,7 @@ export function AssignStep({
     setActiveReceiptId,
     renameReceipt,
     updateItem,
+    splitUnassignedItemsEquallyForActiveReceipt,
   } = useReceiptStore(
     useShallow((state) => {
       const activeReceipt =
@@ -49,6 +50,8 @@ export function AssignStep({
         setActiveReceiptId: state.setActiveReceiptId,
         renameReceipt: state.renameReceipt,
         updateItem: state.updateItem,
+        splitUnassignedItemsEquallyForActiveReceipt:
+          state.splitUnassignedItemsEquallyForActiveReceipt,
       };
     }),
   );
@@ -112,7 +115,9 @@ export function AssignStep({
           validPeopleSet={validPeopleSet}
           activeItemIndex={activeItemIndex}
           onActiveItemIndexChange={onActiveItemIndexChange}
+          onItemsSubPhaseChange={onItemsSubPhaseChange}
           onUpdateItem={updateItem}
+          onSplitUnassignedItemsEqually={splitUnassignedItemsEquallyForActiveReceipt}
           currency={activeCurrency}
         />
       ) : (
@@ -137,7 +142,9 @@ type AssignPhaseProps = {
   validPeopleSet: Set<string>;
   activeItemIndex: number;
   onActiveItemIndexChange: (index: number) => void;
+  onItemsSubPhaseChange: (phase: ItemsSubPhase) => void;
   onUpdateItem: (id: string, updater: (current: EditableItem) => EditableItem) => void;
+  onSplitUnassignedItemsEqually: () => void;
   currency: string;
 };
 
@@ -147,11 +154,15 @@ function AssignPhase({
   validPeopleSet,
   activeItemIndex,
   onActiveItemIndexChange,
+  onItemsSubPhaseChange,
   onUpdateItem,
+  onSplitUnassignedItemsEqually,
   currency,
 }: AssignPhaseProps) {
   const activeItem = items[activeItemIndex] ?? null;
   const isAssigned = activeItem ? isItemAssigned(activeItem, validPeopleSet) : false;
+  const unassignedItemCount = items.filter((item) => !isItemAssigned(item, validPeopleSet)).length;
+  const canSplitRest = people.length > 0 && unassignedItemCount > 0;
 
   const selectedIds = activeItem?.assignment.personIds ?? [];
   const weights = activeItem?.assignment.weights;
@@ -173,6 +184,13 @@ function AssignPhase({
   const handleSelectNone = () => {
     if (!activeItem) return;
     onUpdateItem(activeItem.id, () => selectNone(activeItem));
+  };
+
+  const handleSplitRest = () => {
+    if (!canSplitRest) return;
+    onSplitUnassignedItemsEqually();
+    onActiveItemIndexChange(0);
+    onItemsSubPhaseChange('review');
   };
 
   const handleUnequalToggle = () => {
@@ -226,7 +244,7 @@ function AssignPhase({
   return (
     <div className="space-y-5">
       {/* Counter + nav arrows */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div>
           <p className="text-xs font-bold tracking-widest text-on-surface-variant uppercase">
             Assigning Items
@@ -238,7 +256,17 @@ function AssignPhase({
             Item {activeItemIndex + 1} of {items.length}
           </p>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 self-end md:self-auto">
+          <button
+            type="button"
+            data-testid="assign-split-rest-btn"
+            onClick={handleSplitRest}
+            disabled={!canSplitRest}
+            className="flex h-10 items-center gap-1.5 rounded-xl bg-primary px-3 text-sm font-bold whitespace-nowrap text-on-primary transition-all hover:opacity-90 disabled:bg-surface-container-high disabled:text-on-surface-variant disabled:opacity-60"
+          >
+            <span className="material-symbols-outlined text-base">group</span>
+            Split unassigned
+          </button>
           <button
             type="button"
             data-testid="assign-prev-item-btn"
@@ -305,38 +333,6 @@ function AssignPhase({
       <div className="flex items-center justify-between">
         <span className="text-base font-semibold text-on-surface">Who's sharing?</span>
         <div className="flex gap-3">
-          {canToggleUnequal && (
-            <div className="flex overflow-hidden rounded-lg border border-outline-variant/40">
-              <button
-                type="button"
-                onClick={() => {
-                  if (unequalMode) handleUnequalToggle();
-                }}
-                className={cn(
-                  'px-2.5 py-1 text-xs font-semibold transition-colors',
-                  !unequalMode
-                    ? 'bg-primary text-on-primary'
-                    : 'text-on-surface-variant hover:bg-surface-container',
-                )}
-              >
-                Equal
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  if (!unequalMode) handleUnequalToggle();
-                }}
-                className={cn(
-                  'px-2.5 py-1 text-xs font-semibold transition-colors',
-                  unequalMode
-                    ? 'bg-primary text-on-primary'
-                    : 'text-on-surface-variant hover:bg-surface-container',
-                )}
-              >
-                Unequal
-              </button>
-            </div>
-          )}
           <button
             type="button"
             data-testid="assign-select-all-btn"
@@ -412,6 +408,55 @@ function AssignPhase({
             </button>
           );
         })}
+      </div>
+
+      <div
+        role="group"
+        aria-label="Split"
+        data-testid="assign-split-mode-toggle"
+        className="space-y-2 rounded-xl bg-surface-container-low p-3"
+      >
+        <span className="block text-xs font-bold tracking-widest text-on-surface-variant uppercase">
+          Split
+        </span>
+        <div className="grid grid-cols-2 overflow-hidden rounded-lg border border-outline-variant/40 bg-surface-container-lowest p-0.5">
+          <button
+            type="button"
+            onClick={() => {
+              if (unequalMode) handleUnequalToggle();
+            }}
+            disabled={!canToggleUnequal}
+            className={cn(
+              'flex items-center justify-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-60',
+              !unequalMode
+                ? 'bg-primary text-on-primary shadow-sm'
+                : 'text-on-surface-variant hover:bg-surface-container',
+            )}
+          >
+            <span className="material-symbols-outlined text-sm" aria-hidden="true">
+              drag_handle
+            </span>
+            Equally
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              if (!unequalMode) handleUnequalToggle();
+            }}
+            disabled={!canToggleUnequal}
+            className={cn(
+              'flex items-center justify-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-60',
+              unequalMode
+                ? 'bg-primary text-on-primary shadow-sm'
+                : 'text-on-surface-variant hover:bg-surface-container',
+            )}
+          >
+            <span className="material-symbols-outlined text-sm" aria-hidden="true">
+              pie_chart
+            </span>
+            By shares
+          </button>
+        </div>
       </div>
 
       {/* Weight steppers (shown in unequal mode) */}

--- a/src/features/split-workspace/logic/assignmentActions.test.ts
+++ b/src/features/split-workspace/logic/assignmentActions.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { EditableItem, Person } from '@shared/types';
-import { togglePersonInAssignment, selectAllPeople, selectNone } from './assignmentActions';
+import {
+  togglePersonInAssignment,
+  selectAllPeople,
+  selectNone,
+  splitUnassignedItemsEqually,
+} from './assignmentActions';
 
 const people: Person[] = [
   { id: 'p1', name: 'Alice' },
@@ -116,5 +121,69 @@ describe('weight preservation', () => {
     });
     const result = selectNone(item);
     expect(result.assignment.weights).toBeUndefined();
+  });
+});
+
+describe('splitUnassignedItemsEqually', () => {
+  it('assigns unassigned items to all people equally', () => {
+    const unassignedItem = buildItem({
+      id: 'unassigned',
+      assignment: { mode: 'equal', personId: '', personIds: [] },
+    });
+
+    const result = splitUnassignedItemsEqually([unassignedItem], people);
+
+    expect(result[0].assignment).toEqual({
+      mode: 'equal',
+      personId: '',
+      personIds: ['p1', 'p2', 'p3'],
+      weights: undefined,
+    });
+  });
+
+  it('preserves already assigned items and weighted splits', () => {
+    const weightedItem = buildItem({
+      id: 'weighted',
+      assignment: {
+        mode: 'equal',
+        personId: '',
+        personIds: ['p1', 'p2'],
+        weights: { p1: 2, p2: 1 },
+      },
+    });
+    const unassignedItem = buildItem({
+      id: 'unassigned',
+      assignment: { mode: 'equal', personId: '', personIds: [] },
+    });
+
+    const result = splitUnassignedItemsEqually([weightedItem, unassignedItem], people);
+
+    expect(result[0]).toBe(weightedItem);
+    expect(result[0].assignment.weights).toEqual({ p1: 2, p2: 1 });
+    expect(result[1].assignment.personIds).toEqual(['p1', 'p2', 'p3']);
+  });
+
+  it('treats items assigned only to stale people as unassigned', () => {
+    const staleItem = buildItem({
+      id: 'stale',
+      assignment: { mode: 'equal', personId: '', personIds: ['removed-person'] },
+    });
+
+    const result = splitUnassignedItemsEqually([staleItem], people);
+
+    expect(result[0].assignment.personIds).toEqual(['p1', 'p2', 'p3']);
+  });
+
+  it('leaves items unchanged when there are no people', () => {
+    const unassignedItem = buildItem({
+      id: 'unassigned',
+      assignment: { mode: 'equal', personId: '', personIds: [] },
+    });
+    const items = [unassignedItem];
+
+    const result = splitUnassignedItemsEqually(items, []);
+
+    expect(result).toBe(items);
+    expect(result[0]).toBe(unassignedItem);
   });
 });

--- a/src/features/split-workspace/logic/assignmentActions.ts
+++ b/src/features/split-workspace/logic/assignmentActions.ts
@@ -1,4 +1,5 @@
 import type { EditableItem, Person } from '@shared/types';
+import { isItemAssigned } from '@features/split-workspace/logic/wizardValidation';
 
 export function togglePersonInAssignment(
   personId: string,
@@ -40,4 +41,32 @@ export function selectNone(currentItem: EditableItem): EditableItem {
     ...currentItem,
     assignment: { mode: 'equal' as const, personId: '', personIds: [], weights: undefined },
   };
+}
+
+export function splitUnassignedItemsEqually(
+  items: EditableItem[],
+  people: Person[],
+): EditableItem[] {
+  if (people.length === 0) {
+    return items;
+  }
+
+  const validPeopleSet = new Set(people.map((person) => person.id));
+  const personIds = people.map((person) => person.id);
+
+  return items.map((item) => {
+    if (isItemAssigned(item, validPeopleSet)) {
+      return item;
+    }
+
+    return {
+      ...item,
+      assignment: {
+        mode: 'equal' as const,
+        personId: '',
+        personIds,
+        weights: undefined,
+      },
+    };
+  });
 }

--- a/src/features/split-workspace/stores/receiptStore.test.ts
+++ b/src/features/split-workspace/stores/receiptStore.test.ts
@@ -1,12 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_GEMINI_MODEL } from '@features/receipt-scanner/constants';
 import {
+  defaultDiscountState,
+  defaultGstState,
+  defaultServiceChargeState,
   LOCAL_STORAGE_OCR_SETTINGS_KEY,
   SESSION_STORAGE_GEMINI_API_KEY,
 } from '@features/split-workspace/constants';
 import { useReceiptStore } from '@features/split-workspace/stores/receiptStore';
 import { useScanStore } from '@features/receipt-scanner/stores/scanStore';
 import { useGeminiStore } from '@features/split-workspace/stores/geminiStore';
+import type { Person, Receipt } from '@shared/types';
 
 const FIRST_LOADING_MESSAGE = 'Asking Gemini to decipher cryptic cashier handwriting...';
 const SECOND_LOADING_MESSAGE = 'Negotiating with suspiciously smudged totals...';
@@ -452,5 +456,65 @@ describe('receiptStore additional coverage', () => {
     const receipt = useReceiptStore.getState().receipts.find((r) => r.id === receiptId)!;
     expect(receipt.receiptTotalInput).toBe('42.00');
     expect(receipt.currency).toBe('USD');
+  });
+
+  it('splitUnassignedItemsEquallyForActiveReceipt updates only the active receipt', () => {
+    const people: Person[] = [
+      { id: 'p1', name: 'Alice' },
+      { id: 'p2', name: 'Bob' },
+    ];
+    const receipts: Receipt[] = [
+      {
+        id: 'r1',
+        name: 'Receipt 1',
+        items: [
+          {
+            id: 'r1-unassigned',
+            name: 'Unassigned',
+            amountInput: '10.00',
+            discountPercentInput: '',
+            assignment: { mode: 'equal', personId: '', personIds: [] },
+          },
+        ],
+        discount: { ...defaultDiscountState },
+        serviceCharge: { ...defaultServiceChargeState },
+        gst: { ...defaultGstState },
+        receiptTotalInput: '',
+        currency: 'SGD',
+        exchangeRateOverride: null,
+      },
+      {
+        id: 'r2',
+        name: 'Receipt 2',
+        items: [
+          {
+            id: 'r2-unassigned',
+            name: 'Other receipt item',
+            amountInput: '12.00',
+            discountPercentInput: '',
+            assignment: { mode: 'equal', personId: '', personIds: [] },
+          },
+        ],
+        discount: { ...defaultDiscountState },
+        serviceCharge: { ...defaultServiceChargeState },
+        gst: { ...defaultGstState },
+        receiptTotalInput: '',
+        currency: 'SGD',
+        exchangeRateOverride: null,
+      },
+    ];
+    useReceiptStore.setState({
+      initialized: true,
+      people,
+      receipts,
+      activeReceiptId: 'r1',
+    });
+
+    useReceiptStore.getState().splitUnassignedItemsEquallyForActiveReceipt();
+
+    const state = useReceiptStore.getState();
+    expect(state.receipts[0].items[0].assignment.personIds).toEqual(['p1', 'p2']);
+    expect(state.receipts[1]).toBe(receipts[1]);
+    expect(state.receipts[1].items[0].assignment.personIds).toEqual([]);
   });
 });

--- a/src/features/split-workspace/stores/receiptStore.ts
+++ b/src/features/split-workspace/stores/receiptStore.ts
@@ -18,6 +18,7 @@ import {
   normalizeItemAssignments,
   syncItemsWithPeople,
 } from '@features/split-workspace/logic/simpleAssignments';
+import { splitUnassignedItemsEqually } from '@features/split-workspace/logic/assignmentActions';
 
 // ---------------------------------------------------------------------------
 // Module-level helpers
@@ -73,6 +74,7 @@ type ReceiptStoreActions = {
   addItem: () => void;
   removeItem: (itemId: string) => void;
   updateItem: (itemId: string, updater: (item: EditableItem) => EditableItem) => void;
+  splitUnassignedItemsEquallyForActiveReceipt: () => void;
   setDiscount: (next: ChargeState) => void;
   setServiceCharge: (next: ChargeState) => void;
   setGst: (next: ChargeState) => void;
@@ -237,6 +239,15 @@ export const useReceiptStore = create<ReceiptStore>((set, get) => {
         receipts: state.receipts.map((r) =>
           r.id === state.activeReceiptId
             ? { ...r, items: r.items.map((item) => (item.id === itemId ? updater(item) : item)) }
+            : r,
+        ),
+      }));
+    },
+    splitUnassignedItemsEquallyForActiveReceipt: () => {
+      set((state) => ({
+        receipts: state.receipts.map((r) =>
+          r.id === state.activeReceiptId
+            ? { ...r, items: splitUnassignedItemsEqually(r.items, state.people) }
             : r,
         ),
       }));


### PR DESCRIPTION
Closes #48

## Summary
- add a Split unassigned shortcut for assigning unassigned active-receipt items equally
- preserve existing assigned and weighted share assignments
- move split method selection below the people selector with Equally and By shares options