### PR TITLE
Update default Gemini model to gemini-3.1-flash-lite

### DIFF
--- a/src/features/receipt-scanner/constants.ts
+++ b/src/features/receipt-scanner/constants.ts
@@ -1,5 +1,5 @@
 export const GEMINI_MODELS = [
-  'gemini-3.1-flash-lite-preview',
+  'gemini-3.1-flash-lite',
   'gemini-3-flash-preview',
   'gemini-2.5-flash',
   'gemini-2.5-flash-lite',


### PR DESCRIPTION
## Summary
- Replaces `gemini-3.1-flash-lite-preview` with the stable `gemini-3.1-flash-lite` model ID in `GEMINI_MODELS`

## Test plan
- [ ] Verify receipt scanning works with the updated model ID
- [ ] Confirm the model selector in the UI shows the correct model name